### PR TITLE
Switch install docs to PyPI (uvx delta-exchange-mcp)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Auth spec lives at `source/includes/_authentication.md` (signing payload format,
 **Local stdio only.** Each user runs the server as a subprocess of their MCP client via `uvx`:
 
 ```bash
-uvx --from git+https://github.com/delta-exchange/delta-exchange-mcp.git delta-exchange-mcp
+uvx delta-exchange-mcp
 ```
 
 There is intentionally **no HTTP transport, no Docker image, and no shared hosted endpoint**. Per-user API keys can't safely route through a shared HTTP server, and the financial-tool nature of this MCP means users should be able to read the code that runs against their account. If you find yourself adding `streamable-http`, `transport=` flags, or a `Dockerfile`, stop and discuss first.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # delta-exchange-mcp
 
 ![Status: Beta](https://img.shields.io/badge/status-beta-orange)
+[![PyPI version](https://img.shields.io/pypi/v/delta-exchange-mcp)](https://pypi.org/project/delta-exchange-mcp/)
 
 Official MCP (Model Context Protocol) server for **Delta Exchange India**. Lets AI assistants — Claude Desktop, Claude Code, Cursor, Zed, Codex — query Delta Exchange market data and your own account (read-only) through standardized tools.
 
@@ -17,10 +18,10 @@ Official MCP (Model Context Protocol) server for **Delta Exchange India**. Lets 
 Sanity-check the install:
 
 ```bash
-uvx --from git+https://github.com/delta-exchange/delta-exchange-mcp.git delta-exchange-mcp --help
+uvx delta-exchange-mcp --help
 ```
 
-The server runs **local stdio only**: your MCP client launches it as a subprocess, and your API keys never leave your machine. `uvx` re-fetches the repo on each launch — pin a commit with `git+https://...@<sha>` for reproducibility.
+The server runs **local stdio only**: your MCP client launches it as a subprocess, and your API keys never leave your machine. `uvx` resolves the latest published version from PyPI on each launch — pin a specific version with `uvx "delta-exchange-mcp==0.1.0"` for reproducibility.
 
 ## Install in your MCP client
 
@@ -32,7 +33,7 @@ claude mcp add delta-exchange-mcp \
   --env DELTA_MCP_ENV=india_prod \
   --env DELTA_API_KEY=your-api-key \
   --env DELTA_API_SECRET=your-api-secret \
-  -- uvx --from git+https://github.com/delta-exchange/delta-exchange-mcp.git delta-exchange-mcp
+  -- uvx delta-exchange-mcp
 ```
 
 `--scope user` makes the server available across all projects. Drop the API-key envs for market-only mode. Verify with `claude mcp list`.
@@ -44,7 +45,7 @@ Add to `~/.codex/config.toml`:
 ```toml
 [mcp_servers.delta-exchange-mcp]
 command = "uvx"
-args = ["--from", "git+https://github.com/delta-exchange/delta-exchange-mcp.git", "delta-exchange-mcp"]
+args = ["delta-exchange-mcp"]
 env = { DELTA_MCP_ENV = "india_prod", DELTA_API_KEY = "your-api-key", DELTA_API_SECRET = "your-api-secret" }
 ```
 
@@ -57,11 +58,7 @@ Add to your MCP client's config file:
   "mcpServers": {
     "delta-exchange": {
       "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/delta-exchange/delta-exchange-mcp.git",
-        "delta-exchange-mcp"
-      ],
+      "args": ["delta-exchange-mcp"],
       "env": {
         "DELTA_MCP_ENV": "india_prod",
         "DELTA_API_KEY": "your-api-key",
@@ -73,6 +70,16 @@ Add to your MCP client's config file:
 ```
 
 `DELTA_API_KEY` / `DELTA_API_SECRET` are **optional** — without them, only the public market tools register.
+
+### Install from source (optional)
+
+To run an unreleased commit or your own fork instead of the PyPI release:
+
+```bash
+uvx --from git+https://github.com/delta-exchange/delta-exchange-mcp.git delta-exchange-mcp
+```
+
+Append `@<branch-or-sha>` to the URL to pin to a specific commit.
 
 ## API keys (optional, for account tools)
 


### PR DESCRIPTION
## Summary

- delta-exchange-mcp 0.1.0 is now published on PyPI (https://pypi.org/project/delta-exchange-mcp/), so users can install with the simple `uvx delta-exchange-mcp` invocation instead of the verbose `uvx --from git+https://github.com/...` form.
- README and CLAUDE.md install snippets (Claude Code, Codex, generic JSON config) updated to use the PyPI path.
- The git URL form is preserved under a new **Install from source (optional)** subsection for users who want to run an unreleased commit or a fork.
- Added a PyPI version badge to the README header alongside the existing Beta badge.

No code changes, no version bump, no new release — only docs.

## Test plan

- [x] `delta-exchange-mcp 0.1.0` verified live on PyPI: `curl https://pypi.org/pypi/delta-exchange-mcp/json` returns `version: "0.1.0"`.
- [x] `uvx delta-exchange-mcp` confirmed end-to-end against `india_prod`: `get_ticker`, `get_orderbook`, `get_recent_trades`, `list_tickers` all returned live data through a freshly-spawned process.
- [x] `grep -n "git+https" README.md CLAUDE.md` confirms the git URL remains only in the new source-install fallback subsection.
- [ ] Reviewer: render README on GitHub and confirm both badges show + code blocks compile.
- [ ] Reviewer: copy-paste the Claude Code / Codex / generic-JSON snippets into a throwaway client config and confirm `✓ Connected`.