### PR TITLE
Add RELEASING.md release runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ![Status: Beta](https://img.shields.io/badge/status-beta-orange)
 [![PyPI version](https://img.shields.io/pypi/v/delta-exchange-mcp)](https://pypi.org/project/delta-exchange-mcp/)
 
-Official MCP (Model Context Protocol) server for **Delta Exchange India**. Lets AI assistants — Claude Desktop, Claude Code, Cursor, Zed, Codex — query Delta Exchange market data and your own account (read-only) through standardized tools.
+Official MCP (Model Context Protocol) server for **Delta Exchange India**. Lets AI assistants (Claude Desktop, Claude Code, Cursor, Zed, Codex) query Delta Exchange market data and your own account (read-only) through standardized tools.
 
-> **Status — Beta.** Functional and used internally, but the tool surface and configuration may still change. Please [open an issue](https://github.com/delta-exchange/delta-exchange-mcp/issues) for bugs, missing tools, or rough edges — early reports directly shape what ships next.
+> **Status:** Beta. Functional and used internally, but the tool surface and configuration may still change. Please [open an issue](https://github.com/delta-exchange/delta-exchange-mcp/issues) for bugs, missing tools, or rough edges. Early reports directly shape what ships next.
 
-**What you get:** 9 public market-data tools + 12 authenticated read-only account tools (positions, orders, fills, wallet, stats, leverage, preferences, profile). **No mutations** — the server cannot place, edit, or cancel orders.
+**What you get:** 9 public market-data tools + 12 authenticated read-only account tools (positions, orders, fills, wallet, stats, leverage, preferences, profile). **No mutations.** The server cannot place, edit, or cancel orders.
 
 ---
 
@@ -21,7 +21,7 @@ Sanity-check the install:
 uvx delta-exchange-mcp --help
 ```
 
-The server runs **local stdio only**: your MCP client launches it as a subprocess, and your API keys never leave your machine. `uvx` resolves the latest published version from PyPI on each launch — pin a specific version with `uvx "delta-exchange-mcp==0.1.0"` for reproducibility.
+The server runs **local stdio only**: your MCP client launches it as a subprocess, and your API keys never leave your machine. `uvx` resolves the latest published version from PyPI on each launch. To pin a specific version, use `uvx "delta-exchange-mcp==0.1.0"`.
 
 ## Install in your MCP client
 
@@ -69,7 +69,7 @@ Add to your MCP client's config file:
 }
 ```
 
-`DELTA_API_KEY` / `DELTA_API_SECRET` are **optional** — without them, only the public market tools register.
+`DELTA_API_KEY` / `DELTA_API_SECRET` are **optional**: without them, only the public market tools register.
 
 ### Install from source (optional)
 
@@ -84,7 +84,7 @@ Append `@<branch-or-sha>` to the URL to pin to a specific commit.
 ## API keys (optional, for account tools)
 
 1. Create a key at [delta.exchange/app/account/manageapikeys](https://www.delta.exchange/app/account/manageapikeys) (testnet: [demo.delta.exchange](https://demo.delta.exchange/app/account/manageapikeys)).
-2. Both `api_key` and `api_secret` are shown **once at creation** — save the secret immediately; it can't be re-derived.
+2. Both `api_key` and `api_secret` are shown **once at creation**. Save the secret immediately; it can't be re-derived.
 3. **Read Data** permission is enough. Trading permission is not required and not used.
 4. Recommended: whitelist your IP on the key. Delta blocks non-whitelisted IPs and surfaces your current IP in the error message if it fires.
 5. **Match the environment**: prod keys with `DELTA_MCP_ENV=india_prod`, demo keys with `DELTA_MCP_ENV=india_testnet`. Mixing them returns `InvalidApiKey`.
@@ -94,7 +94,7 @@ Append `@<branch-or-sha>` to the URL to pin to a specific commit.
 | Var | Default | Purpose |
 |---|---|---|
 | `DELTA_MCP_ENV` | `india_prod` | `india_prod` or `india_testnet`. |
-| `DELTA_API_KEY` | _(unset)_ | API key. Optional — when set with `DELTA_API_SECRET`, account tools register. |
+| `DELTA_API_KEY` | _(unset)_ | API key. Optional; when set with `DELTA_API_SECRET`, account tools register. |
 | `DELTA_API_SECRET` | _(unset)_ | API secret matching `DELTA_API_KEY`. |
 
 ## Tools
@@ -132,13 +132,13 @@ Once connected, you can ask things like:
 - "List my fills from the last 24 hours grouped by symbol."
 - "How much USDT do I have free vs blocked in margin?"
 
-The assistant picks the right tool based on the question — you don't need to name the tool.
+The assistant picks the right tool based on the question. You don't need to name the tool.
 
 ## Development
 
 ```bash
 uv sync                       # install deps
-uv run pytest                 # run tests (no network — respx-mocked)
+uv run pytest                 # run tests (no network, respx-mocked)
 uv run ruff check src tests   # lint
 uv run delta-exchange-mcp     # run server (stdio)
 ```
@@ -158,6 +158,8 @@ DELTA_API_KEY=... DELTA_API_SECRET=... \
 # web UI
 bash scripts/inspect.sh        # → http://localhost:6274
 ```
+
+Maintainers: see [`RELEASING.md`](RELEASING.md) for the release procedure.
 
 ## Roadmap
 
@@ -180,5 +182,5 @@ Please redact `api_key` / `api_secret` from any logs or screenshots before attac
 ## Safety
 
 - **No mutations.** Every tool is GET. The server cannot place, edit, or cancel orders.
-- **Local stdio only.** Per-user keys never leave your machine — no shared hosted endpoint.
+- **Local stdio only.** Per-user keys never leave your machine; no shared hosted endpoint.
 - **Read the code.** It's a financial-tool MCP; treat it like one.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,115 @@
+# Releasing `delta-exchange-mcp`
+
+Runbook for cutting a new version to PyPI and GitHub. Aimed at maintainers with PyPI write access on the `delta-exchange-mcp` project and write access to this repo.
+
+This covers: bumping the version, publishing to PyPI, tagging, drafting the GitHub release. It does **not** cover CHANGELOG bookkeeping (GitHub release notes are the chronicle for now) or automatic version bumping.
+
+## What gets versioned
+
+The `version` field in `pyproject.toml` is the single source of truth. The `delta-exchange-mcp/<version>` string in `User-Agent` and `Source` request headers is derived from it (see `src/delta_exchange_mcp/client.py`, which reads `importlib.metadata.version("delta-exchange-mcp")`). Bumping the field is enough; nothing else in the code needs to change.
+
+SemVer while in Beta:
+
+- Patch (`0.1.0` → `0.1.1`) for bug fixes and doc-only releases when you want the rendered PyPI page to refresh.
+- Minor (`0.1.x` → `0.2.0`) for new tools, env variables, or behavior changes.
+- Major bumps are deferred until exiting Beta.
+
+## One-time prerequisites
+
+1. PyPI account with maintainer access on `delta-exchange-mcp`: https://pypi.org/manage/project/delta-exchange-mcp/
+2. A **project-scoped** PyPI API token created under *Manage project → Settings → Create a token*. Store it locally as `UV_PUBLISH_TOKEN` (e.g. in your shell rc or 1Password). Never check it in. Do not reuse account-scoped tokens past the initial-claim release.
+3. `gh` CLI logged in (`gh auth status` is green).
+4. Clean working tree on an up-to-date `main` (`git status` empty, `git pull --ff-only`).
+
+## Cut a release
+
+```bash
+# 1. Pick the new version
+NEW_VERSION=0.1.1
+
+# 2. Bump pyproject.toml
+sed -i '' "s/^version = \".*\"/version = \"$NEW_VERSION\"/" pyproject.toml
+git diff pyproject.toml          # sanity check the diff
+
+# 3. Run tests + lint locally
+uv sync
+uv run pytest
+uv run ruff check src tests scripts
+
+# 4. Commit + tag
+git add pyproject.toml
+git commit -m "Release v$NEW_VERSION"
+git tag -a "v$NEW_VERSION" -m "v$NEW_VERSION"
+
+# 5. Build + publish to PyPI
+rm -rf dist/
+uv build
+uv publish                       # reads UV_PUBLISH_TOKEN from env
+
+# 6. Push commit + tag
+git push origin main "v$NEW_VERSION"
+
+# 7. Create the GitHub release (notes template below)
+gh release create "v$NEW_VERSION" --title "v$NEW_VERSION" --notes-file /tmp/release-notes.md
+```
+
+If `uv publish` fails after step 4 (token missing, network glitch), drop the tag (`git tag -d "v$NEW_VERSION"`), fix the issue, and start from step 4 again. PyPI rejects re-uploading the same version, so don't re-run step 5 with the same `NEW_VERSION` after a partial success.
+
+## Release-notes template
+
+Paste into `/tmp/release-notes.md` before step 7:
+
+```markdown
+## Added
+- ...
+
+## Fixed
+- ...
+
+## Changed
+- ...
+
+## Install
+
+\`\`\`bash
+uvx "delta-exchange-mcp==<NEW_VERSION>"
+\`\`\`
+```
+
+Drop sections that don't apply. Keep bullets terse, link to PRs / issues by number.
+
+## Pre-releases (optional)
+
+For an experimental cut you don't want `uvx delta-exchange-mcp` to resolve to, use a SemVer pre-release suffix (`0.2.0a1`, `0.2.0rc1`) and add `--prerelease` to `gh release create`. Both `uv` and `pip` skip pre-releases by default, so end users on the floating install path stay on the last stable version.
+
+## Post-release verification
+
+```bash
+# 1. PyPI shows the new version
+curl -s https://pypi.org/pypi/delta-exchange-mcp/json | jq '.info.version'
+
+# 2. Fresh install resolves to the new version (clears uvx cache)
+uvx --refresh delta-exchange-mcp --help
+
+# 3. Smoke test public tools through the freshly-spawned server
+bash scripts/inspect.sh --cli --method tools/list
+bash scripts/inspect.sh --cli --method tools/call --tool-name get_ticker --tool-arg symbol=BTCUSD
+```
+
+## Rolling back a bad release
+
+PyPI does **not** allow overwriting a published version. If a release is broken:
+
+1. **Yank** the version on PyPI: *Manage project → Releases → yank*. Yanking keeps the version installable for users with an exact pin but hides it from floating resolution (`uvx delta-exchange-mcp` will skip it).
+2. Cut a new patch version with the fix following the procedure above.
+3. Leave the original GitHub release and tag in place for history. Delete them only if you also yanked the corresponding PyPI release.
+
+## Future: automate with Trusted Publishers
+
+The manual procedure is intentional for the Beta phase. The planned next step is **PyPI Trusted Publishers** (GitHub Actions OIDC, no stored tokens):
+
+1. Add a Pending Publisher on PyPI pointing at `delta-exchange/delta-exchange-mcp`, workflow `release.yml`, environment `pypi`.
+2. Create a `pypi` environment in GitHub repo settings (optionally with manual-approval protection).
+3. Add `.github/workflows/release.yml` that triggers on `v*` tag pushes, runs `uv build`, and uses `pypa/gh-action-pypi-publish@release/v1`.
+
+Once wired, steps 5–7 of the manual procedure collapse into a single `git push origin "v$NEW_VERSION"` and CI handles the upload + release creation. Tracked as a follow-up; do not assume it's in place when running this runbook.


### PR DESCRIPTION
## Summary

- Adds `RELEASING.md` at repo root: prereqs, the copy-pasteable cut-a-release procedure (version bump → tests → tag → `uv build` / `uv publish` → push → `gh release create`), release-notes template, pre-release handling, post-release verification, and yank/rollback steps.
- Notes that Trusted Publishers + GitHub Actions OIDC is the planned follow-up; the manual runbook reflects the current reality of how `0.1.0` was shipped.
- Adds a one-line Maintainers pointer at the end of the README Development section so the runbook is discoverable from the entry page.
- Minor README copy polish along the way.

No code, version, or release changes in this PR.

## Test plan

- [ ] Reviewer: render `RELEASING.md` on GitHub and confirm code blocks copy-paste cleanly into a shell.
- [ ] Reviewer: confirm the Maintainers link in the README's Development section resolves to the new file.
- [ ] On the next release: follow `RELEASING.md` end-to-end without falling back to memory. Anything missing or ambiguous gets fixed in that same release PR.