### PR TITLE
Patch short-option unrealized_pnl client-side (#9)

### DIFF
--- a/src/delta_exchange_mcp/tools/account.py
+++ b/src/delta_exchange_mcp/tools/account.py
@@ -22,6 +22,66 @@ def _csv_ints(values: list[int] | None) -> str | None:
     return ",".join(str(v) for v in values)
 
 
+_OPTION_CONTRACT_TYPES = {"call_options", "put_options"}
+
+
+def _is_option(pos: dict[str, Any]) -> bool:
+    ctype = pos.get("contract_type")
+    if not ctype and isinstance(pos.get("product"), dict):
+        ctype = pos["product"].get("contract_type")
+    if ctype in _OPTION_CONTRACT_TYPES:
+        return True
+    symbol = pos.get("product_symbol") or ""
+    return isinstance(symbol, str) and (symbol.startswith("C-") or symbol.startswith("P-"))
+
+
+def _lookup_contract_value(pos: dict[str, Any]) -> float | None:
+    raw = pos.get("contract_value")
+    if raw is None and isinstance(pos.get("product"), dict):
+        raw = pos["product"].get("contract_value")
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _patch_short_option_pnl(result: Any) -> Any:
+    """Server returns unsigned `unrealized_pnl` (premium value) for short options.
+    Recompute the signed P&L for those positions; leave others untouched.
+
+    Reason: upstream bug — for short option positions the API returns
+    mark_price * |size| * contract_value (premium value), ignoring the position
+    direction. Futures and long options are unaffected. See GH #9.
+    """
+    if not isinstance(result, dict):
+        return result
+    positions = result.get("result")
+    if not isinstance(positions, list):
+        return result
+    for pos in positions:
+        if not isinstance(pos, dict) or not _is_option(pos):
+            continue
+        size_raw = pos.get("size")
+        try:
+            size = int(size_raw)
+        except (TypeError, ValueError):
+            continue
+        if size >= 0:
+            continue
+        try:
+            entry = float(pos["entry_price"])
+            mark = float(pos["mark_price"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        contract_value = _lookup_contract_value(pos)
+        if contract_value is None:
+            continue
+        pos["unrealized_pnl"] = str((mark - entry) * size * contract_value)
+    return result
+
+
 def register(mcp: FastMCP, client: DeltaClient) -> None:
     @mcp.tool()
     async def get_positions(
@@ -48,8 +108,15 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
             description="Subset of: perpetual_futures, call_options, put_options.",
         ),
     ) -> dict[str, Any]:
-        """All open margined positions, optionally filtered."""
-        return await client.get(
+        """All open margined positions, optionally filtered.
+
+        Note on `unrealized_pnl` for short options: the upstream API returns
+        the absolute premium value (unsigned) rather than the signed mark-to-market
+        P&L. This tool patches the field client-side using
+        (mark_price - entry_price) * size * contract_value, with `size` signed.
+        Long options and futures pass through unchanged. See GH #9.
+        """
+        result = await client.get(
             "/positions/margined",
             params={
                 "product_ids": _csv_ints(product_ids),
@@ -57,6 +124,7 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
             },
             auth=True,
         )
+        return _patch_short_option_pnl(result)
 
     @mcp.tool()
     async def get_wallet_balances() -> dict[str, Any]:

--- a/tests/test_account_tools.py
+++ b/tests/test_account_tools.py
@@ -17,6 +17,7 @@ from mcp.server.fastmcp import FastMCP
 from delta_exchange_mcp.client import DeltaClient
 from delta_exchange_mcp.config import INDIA_TESTNET_REST, Config
 from delta_exchange_mcp.tools import account
+from delta_exchange_mcp.tools.account import _patch_short_option_pnl
 
 
 def _client() -> DeltaClient:
@@ -210,3 +211,120 @@ async def test_get_profile():
     route = respx.get(f"{INDIA_TESTNET_REST}/profile").mock(return_value=_ok())
     await _call_tool("get_profile")
     assert route.called
+
+
+# --- GH #9: short-option unrealized_pnl sign fix ---------------------------
+
+
+def _short_call_buggy() -> dict[str, Any]:
+    # Matches the example response in GH #9 (C-BTC-78500-050626 short 10).
+    return {
+        "product_symbol": "C-BTC-78500-050626",
+        "contract_type": "call_options",
+        "size": -10,
+        "entry_price": "1529",
+        "mark_price": "1533.26",
+        "contract_value": "0.001",
+        "unrealized_pnl": "15.41",
+    }
+
+
+def _short_put_buggy() -> dict[str, Any]:
+    return {
+        "product_symbol": "P-BTC-70000-050626",
+        "contract_type": "put_options",
+        "size": -5,
+        "entry_price": "800",
+        "mark_price": "820",
+        "contract_value": "0.001",
+        "unrealized_pnl": "4.10",
+    }
+
+
+def _long_call_pristine() -> dict[str, Any]:
+    return {
+        "product_symbol": "C-BTC-78500-050626",
+        "contract_type": "call_options",
+        "size": 5,
+        "entry_price": "1529",
+        "mark_price": "1533.26",
+        "contract_value": "0.001",
+        "unrealized_pnl": "0.02",  # already signed for longs
+    }
+
+
+def _short_future_pristine() -> dict[str, Any]:
+    return {
+        "product_symbol": "BTCUSD",
+        "contract_type": "perpetual_futures",
+        "size": -10,
+        "entry_price": "77444",
+        "mark_price": "77432.79",
+        "contract_value": "0.001",
+        "unrealized_pnl": "0.11",  # futures already correct upstream
+    }
+
+
+def test_patch_short_call_overwrites_pnl():
+    out = _patch_short_option_pnl({"result": [_short_call_buggy()]})
+    pnl = float(out["result"][0]["unrealized_pnl"])
+    # (1533.26 - 1529) * -10 * 0.001 = -0.0426
+    assert pnl == pytest.approx(-0.0426, abs=1e-6)
+
+
+def test_patch_short_put_overwrites_pnl():
+    out = _patch_short_option_pnl({"result": [_short_put_buggy()]})
+    pnl = float(out["result"][0]["unrealized_pnl"])
+    # (820 - 800) * -5 * 0.001 = -0.1
+    assert pnl == pytest.approx(-0.1, abs=1e-6)
+
+
+def test_patch_leaves_long_option_untouched():
+    out = _patch_short_option_pnl({"result": [_long_call_pristine()]})
+    assert out["result"][0]["unrealized_pnl"] == "0.02"
+
+
+def test_patch_leaves_short_future_untouched():
+    out = _patch_short_option_pnl({"result": [_short_future_pristine()]})
+    assert out["result"][0]["unrealized_pnl"] == "0.11"
+
+
+def test_patch_skips_when_contract_value_missing():
+    pos = _short_call_buggy()
+    del pos["contract_value"]
+    out = _patch_short_option_pnl({"result": [pos]})
+    # Untouched because we can't compute signed pnl without contract_value.
+    assert out["result"][0]["unrealized_pnl"] == "15.41"
+
+
+def test_patch_detects_option_via_product_symbol_prefix():
+    # contract_type missing but product_symbol starts with C- — should still patch.
+    pos = _short_call_buggy()
+    del pos["contract_type"]
+    out = _patch_short_option_pnl({"result": [pos]})
+    pnl = float(out["result"][0]["unrealized_pnl"])
+    assert pnl == pytest.approx(-0.0426, abs=1e-6)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_margined_positions_patches_short_option_pnl():
+    """End-to-end: tool call returns patched response."""
+    respx.get(f"{INDIA_TESTNET_REST}/positions/margined").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "success": True,
+                "result": [_short_call_buggy(), _short_future_pristine()],
+            },
+        )
+    )
+    result = await _call_tool("get_margined_positions")
+    # FastMCP returns (content, structured) — the structured dict is what we want.
+    structured = result[1] if isinstance(result, tuple) else result
+    positions = structured["result"] if isinstance(structured, dict) else None
+    assert positions is not None, f"unexpected tool result shape: {result!r}"
+    short_call = next(p for p in positions if p["product_symbol"].startswith("C-"))
+    short_future = next(p for p in positions if p["product_symbol"] == "BTCUSD")
+    assert float(short_call["unrealized_pnl"]) == pytest.approx(-0.0426, abs=1e-6)
+    assert short_future["unrealized_pnl"] == "0.11"


### PR DESCRIPTION
## Summary
- Upstream `/positions/margined` returns the absolute premium value for short option positions instead of the signed mark-to-market P&L — so a `-$0.04` loss surfaces as `+$15.41`. Closes #9.
- Adds `_patch_short_option_pnl` in `tools/account.py` and calls it from `get_margined_positions`. Recomputes `unrealized_pnl = (mark - entry) * size * contract_value`, leaving futures and long options untouched.
- Detects options via `contract_type` (or `product.contract_type`, or `product_symbol` prefix `C-`/`P-` as fallback). Silently skips a position if `contract_value` isn't available, so we never produce a worse number than upstream.

## Test plan
- [x] `uv run pytest` — 46 passed (7 new regression tests for: short call, short put, long call untouched, short future untouched, missing contract_value, prefix-detected option, end-to-end through FastMCP).
- [x] `uv run ruff check src tests scripts`
- [ ] Live smoke against `india_prod` against an account with short options to confirm patched value matches the UI.