### PR TITLE
Add get_indices and history wrapper tools (#5, #8)

### DIFF
--- a/src/delta_exchange_mcp/tools/market.py
+++ b/src/delta_exchange_mcp/tools/market.py
@@ -96,10 +96,79 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
         start: int = Field(description="Unix timestamp in seconds, inclusive."),
         end: int = Field(description="Unix timestamp in seconds, inclusive."),
     ) -> dict[str, Any]:
-        """OHLC candles. For funding/mark/OI history prefix the symbol: FUNDING:BTCUSD, MARK:BTCUSD, OI:BTCUSD."""
+        """OHLC candles. For funding/mark/OI history prefer the dedicated tools
+        get_funding_history / get_mark_price_history / get_oi_history (or prefix the
+        symbol manually: FUNDING:BTCUSD, MARK:BTCUSD, OI:BTCUSD).
+        """
         return await client.get(
             "/history/candles",
             params={"symbol": symbol, "resolution": resolution, "start": start, "end": end},
+        )
+
+    @mcp.tool()
+    async def get_funding_history(
+        symbol: str = Field(description="Perpetual symbol, e.g. BTCUSD or ETHUSD."),
+        resolution: Resolution = "1h",
+        start: int = Field(description="Unix timestamp in seconds, inclusive."),
+        end: int = Field(description="Unix timestamp in seconds, inclusive."),
+    ) -> dict[str, Any]:
+        """Historical funding rate candles for a perpetual.
+
+        Use this for basis-trade analysis, computing realized funding over a holding
+        period, or spotting funding-rate extremes. Returns OHLC over the funding rate.
+        """
+        return await client.get(
+            "/history/candles",
+            params={
+                "symbol": f"FUNDING:{symbol}",
+                "resolution": resolution,
+                "start": start,
+                "end": end,
+            },
+        )
+
+    @mcp.tool()
+    async def get_mark_price_history(
+        symbol: str = Field(description="Product symbol, e.g. BTCUSD or C-BTC-66400-010824."),
+        resolution: Resolution = "1m",
+        start: int = Field(description="Unix timestamp in seconds, inclusive."),
+        end: int = Field(description="Unix timestamp in seconds, inclusive."),
+    ) -> dict[str, Any]:
+        """Historical mark-price candles for a product.
+
+        Useful for reconstructing P&L curves, slippage checks against mark, or
+        comparing your fill price to fair value across an interval.
+        """
+        return await client.get(
+            "/history/candles",
+            params={
+                "symbol": f"MARK:{symbol}",
+                "resolution": resolution,
+                "start": start,
+                "end": end,
+            },
+        )
+
+    @mcp.tool()
+    async def get_oi_history(
+        symbol: str = Field(description="Product symbol, e.g. BTCUSD or ETHUSD."),
+        resolution: Resolution = "1h",
+        start: int = Field(description="Unix timestamp in seconds, inclusive."),
+        end: int = Field(description="Unix timestamp in seconds, inclusive."),
+    ) -> dict[str, Any]:
+        """Historical open-interest candles for a product.
+
+        Use to detect positioning extremes, squeeze risk, or OI build-up around
+        events. Returns OHLC over open interest.
+        """
+        return await client.get(
+            "/history/candles",
+            params={
+                "symbol": f"OI:{symbol}",
+                "resolution": resolution,
+                "start": start,
+                "end": end,
+            },
         )
 
     @mcp.tool()
@@ -118,8 +187,25 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
         )
 
     @mcp.tool()
+    async def get_indices() -> dict[str, Any]:
+        """Spot price indices that Delta builds by combining prices from prominent exchanges.
+
+        These indices underlie Delta's futures and options. Each index returns its
+        constituent exchanges + weights, `index_type` (spot_pair / fixed_interest_rate /
+        floating_interest_rate), tick_size, and the underlying/quoting asset.
+
+        Use when you need to understand how a product's mark or settlement price is
+        constructed, audit settlement composition, or assess outage/concentration risk
+        from a single constituent exchange.
+        """
+        return await client.get("/indices")
+
+    @mcp.tool()
     async def get_reference_data() -> dict[str, Any]:
-        """Merged assets + indices listing — useful for symbol/asset metadata lookups."""
+        """Merged assets + indices listing — useful for symbol/asset metadata lookups.
+
+        For index-only queries (composition, weights, index_type) prefer get_indices.
+        """
         assets = await client.get("/assets")
         indices = await client.get("/indices")
         return {"assets": assets, "indices": indices}

--- a/tests/test_market_tools.py
+++ b/tests/test_market_tools.py
@@ -1,9 +1,13 @@
+from typing import Any
+
 import httpx
 import pytest
 import respx
+from mcp.server.fastmcp import FastMCP
 
 from delta_exchange_mcp.client import DeltaClient
 from delta_exchange_mcp.config import INDIA_TESTNET_REST, Config
+from delta_exchange_mcp.tools import market
 
 
 @pytest.fixture
@@ -62,6 +66,82 @@ async def test_none_params_are_stripped_before_send(client: DeltaClient):
     assert "contract_types" not in sent
     assert "states=live" in sent
     assert "page_size=3" in sent
+
+
+async def _call_market_tool(client: DeltaClient, name: str, **kwargs: Any) -> Any:
+    mcp = FastMCP("test")
+    market.register(mcp, client)
+    return await mcp.call_tool(name, kwargs)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_indices_hits_indices_endpoint(client: DeltaClient):
+    route = respx.get(f"{INDIA_TESTNET_REST}/indices").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": []})
+    )
+    await _call_market_tool(client, "get_indices")
+    assert route.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_funding_history_prefixes_symbol(client: DeltaClient):
+    route = respx.get(f"{INDIA_TESTNET_REST}/history/candles").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": []})
+    )
+    await _call_market_tool(
+        client, "get_funding_history", symbol="BTCUSD", resolution="1h", start=1, end=2
+    )
+    url = str(route.calls[0].request.url)
+    assert "symbol=FUNDING%3ABTCUSD" in url
+    assert "resolution=1h" in url
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_mark_price_history_prefixes_symbol(client: DeltaClient):
+    route = respx.get(f"{INDIA_TESTNET_REST}/history/candles").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": []})
+    )
+    await _call_market_tool(
+        client,
+        "get_mark_price_history",
+        symbol="C-BTC-66400-010824",
+        resolution="5m",
+        start=1,
+        end=2,
+    )
+    url = str(route.calls[0].request.url)
+    assert "symbol=MARK%3AC-BTC-66400-010824" in url
+    assert "resolution=5m" in url
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_oi_history_prefixes_symbol(client: DeltaClient):
+    route = respx.get(f"{INDIA_TESTNET_REST}/history/candles").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": []})
+    )
+    await _call_market_tool(
+        client, "get_oi_history", symbol="ETHUSD", resolution="1h", start=1, end=2
+    )
+    url = str(route.calls[0].request.url)
+    assert "symbol=OI%3AETHUSD" in url
+
+
+def test_new_history_tools_are_registered(client: DeltaClient):
+    import asyncio
+
+    mcp = FastMCP("test")
+    market.register(mcp, client)
+    names = {t.name for t in asyncio.run(mcp.list_tools())}
+    assert {
+        "get_indices",
+        "get_funding_history",
+        "get_mark_price_history",
+        "get_oi_history",
+    }.issubset(names)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **get_indices** — standalone tool over `/indices` so LLMs can pull index composition (constituent exchanges, weights, `index_type`) without rummaging through `get_reference_data`. Docstring frames the use cases (mark/settlement-price construction, outage/concentration risk, settlement audit). Closes #5.
- **get_funding_history / get_mark_price_history / get_oi_history** — thin wrappers that inject the `FUNDING:` / `MARK:` / `OI:` symbol prefix into `/history/candles`. Each docstring spells out the user-facing use case (basis trades, P&L reconstruction, positioning extremes), so funding/mark/OI history is discoverable rather than buried inside `get_candles`. Closes #8.
- `get_candles` docstring now points at the new wrappers; `get_reference_data` docstring hints at `get_indices` for index-only queries.

## Test plan
- [x] `uv run pytest` — 44 passed (5 new tests: registration check + URL/prefix assertion for each wrapper + `/indices` route).
- [x] `uv run ruff check src tests scripts`
- [ ] `bash scripts/inspect.sh --cli --method tools/list` to confirm the 4 new tool descriptions render.
- [ ] Live smoke: `get_funding_history symbol=BTCUSD resolution=1h start=<…> end=<…>` against `india_prod`.