### PR TITLE
Add get_settlement_prices and bulk_fills_export tools (#4, #6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 FastMCP server (stdio only) that wraps Delta Exchange India's REST API as MCP tools — public market data unconditionally, plus authenticated read-only account tools when `DELTA_API_KEY`/`DELTA_API_SECRET` are set.
 
+## Style
+
+Don't add typing slop. In particular:
+
+- Don't annotate pytest fixtures (`tmp_path`, `monkeypatch`, etc.) — pytest discovers them by name, the annotation adds nothing.
+- Don't write `**kwargs: Any` / `-> Any` on internal test helpers. If the only honest type is `Any`, leave it off.
+- Use `Any` only when it carries real information: a public boundary that genuinely accepts arbitrary JSON, a return type that is genuinely heterogeneous. Otherwise prefer the real type or no annotation at all.
+- Don't add `from typing import Any` just to satisfy a redundant annotation.
+
 ## Commands
 
 ```bash

--- a/src/delta_exchange_mcp/client.py
+++ b/src/delta_exchange_mcp/client.py
@@ -47,6 +47,14 @@ class DeltaClient:
     async def get(self, path: str, params: dict[str, Any] | None = None, *, auth: bool = False) -> Any:
         return await self._request("GET", path, params=params, auth=auth)
 
+    async def get_raw(self, path: str, params: dict[str, Any] | None = None, *, auth: bool = False) -> bytes:
+        """Like get(), but returns the response body bytes without JSON unwrap.
+
+        Used for binary/CSV endpoints (e.g. /fills/history/download/csv). JSON error
+        envelopes are still inspected — a {success: false, ...} body raises DeltaApiError.
+        """
+        return await self._request("GET", path, params=params, auth=auth, raw=True)
+
     async def _request(
         self,
         method: str,
@@ -55,6 +63,7 @@ class DeltaClient:
         params: dict[str, Any] | None = None,
         json_body: Any = None,
         auth: bool = False,
+        raw: bool = False,
     ) -> Any:
         headers: dict[str, str] = {}
         body_str = ""  # TODO when POST lands in v2
@@ -99,10 +108,31 @@ class DeltaClient:
                 await asyncio.sleep(0.5 * (2**attempt))
                 continue
 
-            return self._unwrap(resp)
+            return self._unwrap_raw(resp) if raw else self._unwrap(resp)
 
         assert last_error is not None
         raise last_error
+
+    @staticmethod
+    def _unwrap_raw(resp: httpx.Response) -> bytes:
+        # Even raw endpoints may return a JSON error envelope on failure — inspect that
+        # path before handing the caller a bytes blob.
+        ctype = resp.headers.get("content-type", "")
+        if "json" in ctype.lower():
+            try:
+                data = resp.json()
+            except ValueError:
+                data = None
+            if isinstance(data, dict) and data.get("success") is False:
+                err = data.get("error") or {}
+                raise DeltaApiError(
+                    code=err.get("code", "unknown"),
+                    context=err.get("context"),
+                    status=resp.status_code,
+                )
+        if resp.status_code >= 400:
+            raise DeltaApiError("http_error", context=resp.text[:500], status=resp.status_code)
+        return resp.content
 
     @staticmethod
     def _unwrap(resp: httpx.Response) -> Any:

--- a/src/delta_exchange_mcp/tools/account.py
+++ b/src/delta_exchange_mcp/tools/account.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -20,6 +21,23 @@ def _csv_ints(values: list[int] | None) -> str | None:
     if not values:
         return None
     return ",".join(str(v) for v in values)
+
+
+def _safe_export_path(output_path: str) -> Path:
+    """Resolve `output_path` and reject anything outside cwd or $HOME.
+
+    Guards against path-traversal and absolute writes to unexpected locations,
+    since this tool is the only one that writes to the user's disk.
+    """
+    raw = Path(output_path).expanduser()
+    resolved = (Path.cwd() / raw).resolve() if not raw.is_absolute() else raw.resolve()
+    cwd = Path.cwd().resolve()
+    home = Path.home().resolve()
+    if not (resolved.is_relative_to(cwd) or resolved.is_relative_to(home)):
+        raise ValueError(
+            f"output_path must be inside cwd ({cwd}) or home ({home}); got {resolved}"
+        )
+    return resolved
 
 
 def register(mcp: FastMCP, client: DeltaClient) -> None:
@@ -196,3 +214,52 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
     async def get_profile() -> dict[str, Any]:
         """User profile."""
         return await client.get("/profile", auth=True)
+
+    @mcp.tool()
+    async def bulk_fills_export(
+        output_path: str = Field(
+            description=(
+                "Where to write the CSV. Must be inside the current working directory or "
+                "the user's home directory; ~ is expanded."
+            )
+        ),
+        start_time_us: int | None = Field(
+            default=None, description="Window start in microseconds epoch."
+        ),
+        end_time_us: int | None = Field(
+            default=None, description="Window end in microseconds epoch."
+        ),
+        product_ids: list[int] | None = None,
+        contract_types: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Bulk-export your fills to a CSV file on disk.
+
+        Use this for full-history analysis, tax reports, or backtesting against your
+        own trade record — anything where the paginated `get_fills` would require
+        dozens of round-trips. Calls `/fills/history/download/csv` and writes the
+        raw CSV to `output_path`. Returns `{path, row_count, size_bytes}`.
+
+        The output path is restricted to the current working directory or the user's
+        home directory to keep the write scope predictable.
+        """
+        resolved = _safe_export_path(output_path)
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        data = await client.get_raw(
+            "/fills/history/download/csv",
+            params={
+                "product_ids": _csv_ints(product_ids),
+                "contract_types": _csv(contract_types),
+                "start_time": start_time_us,
+                "end_time": end_time_us,
+            },
+            auth=True,
+        )
+        resolved.write_bytes(data)
+        # Row count = newline-delimited rows minus header. Be lenient if the response
+        # is empty or missing a trailing newline.
+        row_count = max(0, data.count(b"\n") - 1) if data else 0
+        return {
+            "path": str(resolved),
+            "row_count": row_count,
+            "size_bytes": len(data),
+        }

--- a/src/delta_exchange_mcp/tools/market.py
+++ b/src/delta_exchange_mcp/tools/market.py
@@ -103,6 +103,35 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
         )
 
     @mcp.tool()
+    async def get_settlement_prices(
+        contract_types: list[str] | None = Field(
+            default=None,
+            description="Filter expired products by contract type (e.g. call_options, put_options, futures).",
+        ),
+        page_size: int = Field(default=100, ge=1, le=500),
+        after: str | None = Field(default=None, description="Cursor from previous response's meta.after."),
+    ) -> dict[str, Any]:
+        """Historical settlement prices for expired/settled derivatives.
+
+        Use for post-expiry P&L reconciliation, backtesting against realized
+        settlements, or trade journaling. Each product object in the response carries
+        the settlement details (settlement_time, settlement_price) alongside the
+        product metadata. Returns paginated result + meta cursors.
+
+        Under the hood this is `list_products(states=["expired"])` — Delta exposes
+        settlement data through the products endpoint rather than a dedicated path.
+        """
+        return await client.get(
+            "/products",
+            params={
+                "contract_types": _csv(contract_types),
+                "states": "expired",
+                "page_size": page_size,
+                "after": after,
+            },
+        )
+
+    @mcp.tool()
     async def get_options_chain(
         underlying: str = Field(description="Underlying asset symbol, e.g. BTC or ETH."),
         expiry_date: str = Field(description="Expiry date in DD-MM-YYYY format (note: different from /products)."),

--- a/tests/test_account_tools.py
+++ b/tests/test_account_tools.py
@@ -7,6 +7,7 @@ the MCP server, and asserts the request URL + query string + auth headers.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -17,6 +18,7 @@ from mcp.server.fastmcp import FastMCP
 from delta_exchange_mcp.client import DeltaClient
 from delta_exchange_mcp.config import INDIA_TESTNET_REST, Config
 from delta_exchange_mcp.tools import account
+from delta_exchange_mcp.tools.account import _safe_export_path
 
 
 def _client() -> DeltaClient:
@@ -210,3 +212,93 @@ async def test_get_profile():
     route = respx.get(f"{INDIA_TESTNET_REST}/profile").mock(return_value=_ok())
     await _call_tool("get_profile")
     assert route.called
+
+
+# --- GH #6: bulk_fills_export ----------------------------------------------
+
+
+def test_safe_export_path_accepts_cwd_relative(tmp_path: Any, monkeypatch: Any):
+    monkeypatch.chdir(tmp_path)
+    resolved = _safe_export_path("fills.csv")
+    assert resolved == (tmp_path / "fills.csv").resolve()
+
+
+def test_safe_export_path_accepts_home_tilde():
+    resolved = _safe_export_path("~/fills.csv")
+    assert resolved == (Path.home() / "fills.csv").resolve()
+
+
+def test_safe_export_path_rejects_outside_scope(tmp_path: Any, monkeypatch: Any):
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError, match="must be inside"):
+        _safe_export_path("/etc/passwd")
+
+
+def test_safe_export_path_rejects_dotdot_traversal(tmp_path: Any, monkeypatch: Any):
+    # tmp_path lives under /private/var/... on macOS, neither inside cwd (set below)
+    # nor under $HOME, so a `..` escape from cwd should be rejected.
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    monkeypatch.chdir(sandbox)
+    with pytest.raises(ValueError, match="must be inside"):
+        _safe_export_path("../../../../etc/passwd")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_bulk_fills_export_writes_csv(tmp_path: Any, monkeypatch: Any):
+    monkeypatch.chdir(tmp_path)
+    csv_body = b"id,size,price\n1,10,77000\n2,-5,77100\n"
+    respx.get(f"{INDIA_TESTNET_REST}/fills/history/download/csv").mock(
+        return_value=httpx.Response(
+            200, content=csv_body, headers={"content-type": "text/csv"}
+        )
+    )
+    result = await _call_tool(
+        "bulk_fills_export",
+        output_path="fills.csv",
+        start_time_us=1000,
+        end_time_us=2000,
+        product_ids=[1, 2],
+    )
+    structured = result[1] if isinstance(result, tuple) else result
+    out = (tmp_path / "fills.csv").read_bytes()
+    assert out == csv_body
+    assert structured["row_count"] == 2  # 3 newlines - 1 header
+    assert structured["size_bytes"] == len(csv_body)
+    assert structured["path"].endswith("fills.csv")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_bulk_fills_export_passes_query_params(tmp_path: Any, monkeypatch: Any):
+    monkeypatch.chdir(tmp_path)
+    route = respx.get(f"{INDIA_TESTNET_REST}/fills/history/download/csv").mock(
+        return_value=httpx.Response(200, content=b"a,b\n", headers={"content-type": "text/csv"})
+    )
+    await _call_tool(
+        "bulk_fills_export",
+        output_path="fills.csv",
+        product_ids=[1, 2],
+        contract_types=["perpetual_futures"],
+        start_time_us=100,
+        end_time_us=200,
+    )
+    url = str(route.calls[0].request.url)
+    assert "product_ids=1%2C2" in url
+    assert "contract_types=perpetual_futures" in url
+    assert "start_time=100" in url
+    assert "end_time=200" in url
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_bulk_fills_export_rejects_unsafe_path(tmp_path: Any, monkeypatch: Any):
+    monkeypatch.chdir(tmp_path)
+    # Should not even reach the network — raise before issuing the request.
+    route = respx.get(f"{INDIA_TESTNET_REST}/fills/history/download/csv").mock(
+        return_value=httpx.Response(200, content=b"")
+    )
+    with pytest.raises(Exception):
+        await _call_tool("bulk_fills_export", output_path="/etc/passwd")
+    assert not route.called

--- a/tests/test_account_tools.py
+++ b/tests/test_account_tools.py
@@ -217,26 +217,22 @@ async def test_get_profile():
 # --- GH #6: bulk_fills_export ----------------------------------------------
 
 
-def test_safe_export_path_accepts_cwd_relative(tmp_path: Any, monkeypatch: Any):
+def test_safe_export_path_accepts_cwd_relative(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    resolved = _safe_export_path("fills.csv")
-    assert resolved == (tmp_path / "fills.csv").resolve()
+    assert _safe_export_path("fills.csv") == (tmp_path / "fills.csv").resolve()
 
 
 def test_safe_export_path_accepts_home_tilde():
-    resolved = _safe_export_path("~/fills.csv")
-    assert resolved == (Path.home() / "fills.csv").resolve()
+    assert _safe_export_path("~/fills.csv") == (Path.home() / "fills.csv").resolve()
 
 
-def test_safe_export_path_rejects_outside_scope(tmp_path: Any, monkeypatch: Any):
+def test_safe_export_path_rejects_outside_scope(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     with pytest.raises(ValueError, match="must be inside"):
         _safe_export_path("/etc/passwd")
 
 
-def test_safe_export_path_rejects_dotdot_traversal(tmp_path: Any, monkeypatch: Any):
-    # tmp_path lives under /private/var/... on macOS, neither inside cwd (set below)
-    # nor under $HOME, so a `..` escape from cwd should be rejected.
+def test_safe_export_path_rejects_dotdot_traversal(tmp_path, monkeypatch):
     sandbox = tmp_path / "sandbox"
     sandbox.mkdir()
     monkeypatch.chdir(sandbox)
@@ -246,7 +242,7 @@ def test_safe_export_path_rejects_dotdot_traversal(tmp_path: Any, monkeypatch: A
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_bulk_fills_export_writes_csv(tmp_path: Any, monkeypatch: Any):
+async def test_bulk_fills_export_writes_csv(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     csv_body = b"id,size,price\n1,10,77000\n2,-5,77100\n"
     respx.get(f"{INDIA_TESTNET_REST}/fills/history/download/csv").mock(
@@ -262,16 +258,15 @@ async def test_bulk_fills_export_writes_csv(tmp_path: Any, monkeypatch: Any):
         product_ids=[1, 2],
     )
     structured = result[1] if isinstance(result, tuple) else result
-    out = (tmp_path / "fills.csv").read_bytes()
-    assert out == csv_body
-    assert structured["row_count"] == 2  # 3 newlines - 1 header
+    assert (tmp_path / "fills.csv").read_bytes() == csv_body
+    assert structured["row_count"] == 2
     assert structured["size_bytes"] == len(csv_body)
     assert structured["path"].endswith("fills.csv")
 
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_bulk_fills_export_passes_query_params(tmp_path: Any, monkeypatch: Any):
+async def test_bulk_fills_export_passes_query_params(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     route = respx.get(f"{INDIA_TESTNET_REST}/fills/history/download/csv").mock(
         return_value=httpx.Response(200, content=b"a,b\n", headers={"content-type": "text/csv"})
@@ -293,9 +288,8 @@ async def test_bulk_fills_export_passes_query_params(tmp_path: Any, monkeypatch:
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_bulk_fills_export_rejects_unsafe_path(tmp_path: Any, monkeypatch: Any):
+async def test_bulk_fills_export_rejects_unsafe_path(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    # Should not even reach the network — raise before issuing the request.
     route = respx.get(f"{INDIA_TESTNET_REST}/fills/history/download/csv").mock(
         return_value=httpx.Response(200, content=b"")
     )

--- a/tests/test_market_tools.py
+++ b/tests/test_market_tools.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import httpx
 import pytest
 import respx
@@ -66,7 +64,7 @@ async def test_none_params_are_stripped_before_send(client: DeltaClient):
     assert "page_size=3" in sent
 
 
-async def _call_market_tool(client: DeltaClient, name: str, **kwargs: Any) -> Any:
+async def _call_market_tool(client, name, **kwargs):
     from mcp.server.fastmcp import FastMCP
 
     from delta_exchange_mcp.tools import market

--- a/tests/test_market_tools.py
+++ b/tests/test_market_tools.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import httpx
 import pytest
 import respx
@@ -62,6 +64,38 @@ async def test_none_params_are_stripped_before_send(client: DeltaClient):
     assert "contract_types" not in sent
     assert "states=live" in sent
     assert "page_size=3" in sent
+
+
+async def _call_market_tool(client: DeltaClient, name: str, **kwargs: Any) -> Any:
+    from mcp.server.fastmcp import FastMCP
+
+    from delta_exchange_mcp.tools import market
+
+    mcp = FastMCP("test")
+    market.register(mcp, client)
+    return await mcp.call_tool(name, kwargs)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_settlement_prices_filters_states_expired(client: DeltaClient):
+    route = respx.get(f"{INDIA_TESTNET_REST}/products").mock(
+        return_value=httpx.Response(
+            200, json={"success": True, "result": [], "meta": {"after": None}}
+        )
+    )
+    await _call_market_tool(
+        client,
+        "get_settlement_prices",
+        contract_types=["call_options", "put_options"],
+        page_size=50,
+        after="cur",
+    )
+    url = str(route.calls[0].request.url)
+    assert "states=expired" in url
+    assert "contract_types=call_options%2Cput_options" in url
+    assert "page_size=50" in url
+    assert "after=cur" in url
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **#6 — bulk_fills_export** — new auth tool over `/fills/history/download/csv` that writes raw CSV to disk and returns `{path, row_count, size_bytes}`. Output path is restricted to cwd or `\$HOME` via `_safe_export_path` (rejects absolute writes outside that scope and `..` traversal). This is the only tool in the MCP that writes to disk, so the scope is kept conservative. Closes #6.
- **#4 — get_settlement_prices** — thin wrapper over `/products?states=expired`. Delta's docs route "Settlement Prices" through the products endpoint; no dedicated `/settlement-prices` path exists upstream. The wrapper exists for LLM discoverability — its docstring frames the use case (post-expiry P&L reconciliation, backtesting, trade journaling). Closes #4.
- **`DeltaClient.get_raw`** — new helper for binary/CSV endpoints. Same signing + retry as `get`, but returns response bytes without JSON unwrap. Still inspects `{success: false, ...}` envelopes and raises `DeltaApiError`.

## Test plan
- [x] `uv run pytest` — 47 passed (8 new tests covering path-scope guard, CSV write, query param passthrough, unsafe-path rejection, and settlement-prices filtering).
- [x] `uv run ruff check src tests scripts`
- [ ] Live smoke: `bulk_fills_export output_path=fills.csv start_time_us=… end_time_us=…` against an account with fill history on `india_testnet`; confirm row_count matches actual fills.
- [ ] `bash scripts/inspect.sh --cli --method tools/list` to confirm both new tools are registered.