### PR TITLE
Release v0.2.0: merge issues #3–#10 work to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 FastMCP server (stdio only) that wraps Delta Exchange India's REST API as MCP tools — public market data unconditionally, plus authenticated read-only account tools when `DELTA_API_KEY`/`DELTA_API_SECRET` are set.
 
+## Style
+
+Don't add typing slop. In particular:
+
+- Don't annotate pytest fixtures (`tmp_path`, `monkeypatch`, etc.) — pytest discovers them by name, the annotation adds nothing.
+- Don't write `**kwargs: Any` / `-> Any` on internal test helpers. If the only honest type is `Any`, leave it off.
+- Use `Any` only when it carries real information: a public boundary that genuinely accepts arbitrary JSON, a return type that is genuinely heterogeneous. Otherwise prefer the real type or no annotation at all.
+- Don't add `from typing import Any` just to satisfy a redundant annotation.
+
 ## Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The server runs **local stdio only**: your MCP client launches it as a subproces
 
 ## Install in your MCP client
 
+`DELTA_API_KEY` / `DELTA_API_SECRET` are **optional** in every snippet below — drop them for public-data-only mode. Set `DELTA_MCP_ENV=india_testnet` for testnet.
+
 ### Claude Code
 
 ```bash
@@ -36,27 +38,16 @@ claude mcp add delta-exchange-mcp \
   -- uvx delta-exchange-mcp
 ```
 
-`--scope user` makes the server available across all projects. Drop the API-key envs for market-only mode. Verify with `claude mcp list`.
+`--scope user` makes the server available across all projects. Verify with `claude mcp list`.
 
-### Codex
+### Cursor
 
-Add to `~/.codex/config.toml`:
-
-```toml
-[mcp_servers.delta-exchange-mcp]
-command = "uvx"
-args = ["delta-exchange-mcp"]
-env = { DELTA_MCP_ENV = "india_prod", DELTA_API_KEY = "your-api-key", DELTA_API_SECRET = "your-api-secret" }
-```
-
-### Claude Desktop / Zed / Windsurf / other clients
-
-Add to your MCP client's config file:
+Global: `~/.cursor/mcp.json` (or `%USERPROFILE%\.cursor\mcp.json` on Windows). Project-scoped alternative: `.cursor/mcp.json` in the repo root.
 
 ```json
 {
   "mcpServers": {
-    "delta-exchange": {
+    "delta-exchange-mcp": {
       "command": "uvx",
       "args": ["delta-exchange-mcp"],
       "env": {
@@ -69,17 +60,180 @@ Add to your MCP client's config file:
 }
 ```
 
-`DELTA_API_KEY` / `DELTA_API_SECRET` are **optional**: without them, only the public market tools register.
+Restart Cursor or open **Settings → Tools & MCP** to refresh.
 
-### Install from source (optional)
+### Codex
 
-To run an unreleased commit or your own fork instead of the PyPI release:
+Add to `~/.codex/config.toml`:
 
-```bash
-uvx --from git+https://github.com/delta-exchange/delta-exchange-mcp.git delta-exchange-mcp
+```toml
+[mcp_servers.delta-exchange-mcp]
+command = "uvx"
+args = ["delta-exchange-mcp"]
+env = { DELTA_MCP_ENV = "india_prod", DELTA_API_KEY = "your-api-key", DELTA_API_SECRET = "your-api-secret" }
 ```
 
-Append `@<branch-or-sha>` to the URL to pin to a specific commit.
+### Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json` (macOS / Linux) or `%USERPROFILE%\.codeium\windsurf\mcp_config.json` (Windows). UI route: **Settings → Cascade → Plugins (MCP servers) → Manage Plugins → View raw config**.
+
+```json
+{
+  "mcpServers": {
+    "delta-exchange-mcp": {
+      "command": "uvx",
+      "args": ["delta-exchange-mcp"],
+      "env": {
+        "DELTA_MCP_ENV": "india_prod",
+        "DELTA_API_KEY": "your-api-key",
+        "DELTA_API_SECRET": "your-api-secret"
+      }
+    }
+  }
+}
+```
+
+### Zed
+
+Add to `~/.config/zed/settings.json` (user-level) or `.zed/settings.json` (project-level). Zed uses the top-level key `context_servers` and nests `command` as an object — note the shape difference from other clients:
+
+```json
+{
+  "context_servers": {
+    "delta-exchange-mcp": {
+      "command": {
+        "path": "uvx",
+        "args": ["delta-exchange-mcp"],
+        "env": {
+          "DELTA_MCP_ENV": "india_prod",
+          "DELTA_API_KEY": "your-api-key",
+          "DELTA_API_SECRET": "your-api-secret"
+        }
+      }
+    }
+  }
+}
+```
+
+### VS Code (GitHub Copilot)
+
+Add to `.vscode/mcp.json` in your workspace. The top-level key is `servers` and each entry needs an explicit `"type": "stdio"`:
+
+```json
+{
+  "servers": {
+    "delta-exchange-mcp": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["delta-exchange-mcp"],
+      "env": {
+        "DELTA_MCP_ENV": "india_prod",
+        "DELTA_API_KEY": "your-api-key",
+        "DELTA_API_SECRET": "your-api-secret"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Open **Settings → Developer → Edit config**, or edit directly at:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+- Linux: `~/.config/Claude/claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "delta-exchange-mcp": {
+      "command": "uvx",
+      "args": ["delta-exchange-mcp"],
+      "env": {
+        "DELTA_MCP_ENV": "india_prod",
+        "DELTA_API_KEY": "your-api-key",
+        "DELTA_API_SECRET": "your-api-secret"
+      }
+    }
+  }
+}
+```
+
+Quit and relaunch Claude Desktop for changes to take effect.
+
+## Running a dev / unreleased branch
+
+To test an unreleased commit, branch, or fork before it's on PyPI, swap `uvx delta-exchange-mcp` for `uvx --from git+<repo-url>@<ref> delta-exchange-mcp`. `<ref>` can be a branch, tag, or commit SHA.
+
+CLI sanity check:
+
+```bash
+uvx --from git+https://github.com/delta-exchange/delta-exchange-mcp.git@develop delta-exchange-mcp --help
+```
+
+`uv` caches the git resolution, so to pick up new commits on the same branch:
+
+```bash
+uvx --refresh --from git+https://github.com/delta-exchange/delta-exchange-mcp.git@develop delta-exchange-mcp --help
+```
+
+### In your MCP client config
+
+Replace `args` in any snippet above with the `git+` form. Three flavours:
+
+**Claude Code:**
+
+```bash
+claude mcp add delta-exchange-mcp-dev \
+  --scope user \
+  --env DELTA_MCP_ENV=india_prod \
+  -- uvx --from git+https://github.com/delta-exchange/delta-exchange-mcp.git@develop delta-exchange-mcp
+```
+
+**Cursor / Windsurf / Claude Desktop (any `mcpServers` JSON):**
+
+```json
+{
+  "mcpServers": {
+    "delta-exchange-mcp-dev": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/delta-exchange/delta-exchange-mcp.git@develop",
+        "delta-exchange-mcp"
+      ],
+      "env": {
+        "DELTA_MCP_ENV": "india_prod"
+      }
+    }
+  }
+}
+```
+
+**Zed (nested `command` object):**
+
+```json
+{
+  "context_servers": {
+    "delta-exchange-mcp-dev": {
+      "command": {
+        "path": "uvx",
+        "args": [
+          "--from",
+          "git+https://github.com/delta-exchange/delta-exchange-mcp.git@develop",
+          "delta-exchange-mcp"
+        ],
+        "env": {
+          "DELTA_MCP_ENV": "india_prod"
+        }
+      }
+    }
+  }
+}
+```
+
+Register the dev server under a separate name (e.g. `delta-exchange-mcp-dev`) so it doesn't collide with the PyPI install. The git+URL form rebuilds from source on each launch and is meant for testing unreleased changes — stick with `uvx delta-exchange-mcp` for everyday use.
 
 ## API keys (optional, for account tools)
 

--- a/src/delta_exchange_mcp/client.py
+++ b/src/delta_exchange_mcp/client.py
@@ -47,6 +47,14 @@ class DeltaClient:
     async def get(self, path: str, params: dict[str, Any] | None = None, *, auth: bool = False) -> Any:
         return await self._request("GET", path, params=params, auth=auth)
 
+    async def get_raw(self, path: str, params: dict[str, Any] | None = None, *, auth: bool = False) -> bytes:
+        """Like get(), but returns the response body bytes without JSON unwrap.
+
+        Used for binary/CSV endpoints (e.g. /fills/history/download/csv). JSON error
+        envelopes are still inspected — a {success: false, ...} body raises DeltaApiError.
+        """
+        return await self._request("GET", path, params=params, auth=auth, raw=True)
+
     async def _request(
         self,
         method: str,
@@ -55,6 +63,7 @@ class DeltaClient:
         params: dict[str, Any] | None = None,
         json_body: Any = None,
         auth: bool = False,
+        raw: bool = False,
     ) -> Any:
         headers: dict[str, str] = {}
         body_str = ""  # TODO when POST lands in v2
@@ -99,10 +108,31 @@ class DeltaClient:
                 await asyncio.sleep(0.5 * (2**attempt))
                 continue
 
-            return self._unwrap(resp)
+            return self._unwrap_raw(resp) if raw else self._unwrap(resp)
 
         assert last_error is not None
         raise last_error
+
+    @staticmethod
+    def _unwrap_raw(resp: httpx.Response) -> bytes:
+        # Even raw endpoints may return a JSON error envelope on failure — inspect that
+        # path before handing the caller a bytes blob.
+        ctype = resp.headers.get("content-type", "")
+        if "json" in ctype.lower():
+            try:
+                data = resp.json()
+            except ValueError:
+                data = None
+            if isinstance(data, dict) and data.get("success") is False:
+                err = data.get("error") or {}
+                raise DeltaApiError(
+                    code=err.get("code", "unknown"),
+                    context=err.get("context"),
+                    status=resp.status_code,
+                )
+        if resp.status_code >= 400:
+            raise DeltaApiError("http_error", context=resp.text[:500], status=resp.status_code)
+        return resp.content
 
     @staticmethod
     def _unwrap(resp: httpx.Response) -> Any:

--- a/src/delta_exchange_mcp/tools/account.py
+++ b/src/delta_exchange_mcp/tools/account.py
@@ -31,7 +31,12 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
             description="Underlying asset symbol (e.g. BTC) — returns all positions under it.",
         ),
     ) -> dict[str, Any]:
-        """Open position(s). Pass exactly one of product_id or underlying_asset_symbol."""
+        """Open position(s). Pass exactly one of product_id or underlying_asset_symbol.
+
+        Returns only `entry_price` and `size`. For `realized_pnl`, `realized_funding`,
+        `margin`, `mark_price`, `unrealized_pnl`, `liquidation_price` and other analytical
+        fields, call `get_margined_positions` instead.
+        """
         if (product_id is None) == (not underlying_asset_symbol):
             raise ValueError("pass exactly one of product_id or underlying_asset_symbol")
         return await client.get(
@@ -48,7 +53,19 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
             description="Subset of: perpetual_futures, call_options, put_options.",
         ),
     ) -> dict[str, Any]:
-        """All open margined positions, optionally filtered."""
+        """All open margined positions, optionally filtered.
+
+        Computing notional exposure (especially for options):
+            notional_usd = abs(size) * contract_value * index_price
+
+        Use `index_price` (spot of the underlying), NOT `mark_price` — mark_price for an
+        option is the option premium, so multiplying by it gives the premium value, not the
+        underlying exposure. For a short BTC call with size 10, contract_value 0.001 and
+        BTC index 54_270, notional is 10 * 0.001 * 54_270 = $542.70, not the ~$7.60 you'd
+        get by multiplying the premium.
+
+        `size` is signed: positive = long, negative = short.
+        """
         return await client.get(
             "/positions/margined",
             params={
@@ -60,7 +77,15 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
 
     @mcp.tool()
     async def get_wallet_balances() -> dict[str, Any]:
-        """Wallet balances across all assets. Fields: asset_symbol, balance, available_balance, position_margin."""
+        """Wallet balances across all assets.
+
+        Fields: asset_symbol, balance, available_balance, position_margin,
+        strategy_blocked_amount.
+
+        `strategy_blocked_amount` is collateral reserved by an active Algo Marketplace
+        strategy subscription. It is normal and expected — do not flag it as a risk or
+        anomaly. To release it, the user must stop or unsubscribe from the strategy.
+        """
         return await client.get("/wallet/balances", auth=True)
 
     @mcp.tool()

--- a/src/delta_exchange_mcp/tools/account.py
+++ b/src/delta_exchange_mcp/tools/account.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -20,6 +21,23 @@ def _csv_ints(values: list[int] | None) -> str | None:
     if not values:
         return None
     return ",".join(str(v) for v in values)
+
+
+def _safe_export_path(output_path: str) -> Path:
+    """Resolve `output_path` and reject anything outside cwd or $HOME.
+
+    Guards against path-traversal and absolute writes to unexpected locations,
+    since this tool is the only one that writes to the user's disk.
+    """
+    raw = Path(output_path).expanduser()
+    resolved = (Path.cwd() / raw).resolve() if not raw.is_absolute() else raw.resolve()
+    cwd = Path.cwd().resolve()
+    home = Path.home().resolve()
+    if not (resolved.is_relative_to(cwd) or resolved.is_relative_to(home)):
+        raise ValueError(
+            f"output_path must be inside cwd ({cwd}) or home ({home}); got {resolved}"
+        )
+    return resolved
 
 
 _OPTION_CONTRACT_TYPES = {"call_options", "put_options"}
@@ -288,3 +306,52 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
     async def get_profile() -> dict[str, Any]:
         """User profile."""
         return await client.get("/profile", auth=True)
+
+    @mcp.tool()
+    async def bulk_fills_export(
+        output_path: str = Field(
+            description=(
+                "Where to write the CSV. Must be inside the current working directory or "
+                "the user's home directory; ~ is expanded."
+            )
+        ),
+        start_time_us: int | None = Field(
+            default=None, description="Window start in microseconds epoch."
+        ),
+        end_time_us: int | None = Field(
+            default=None, description="Window end in microseconds epoch."
+        ),
+        product_ids: list[int] | None = None,
+        contract_types: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Bulk-export your fills to a CSV file on disk.
+
+        Use this for full-history analysis, tax reports, or backtesting against your
+        own trade record — anything where the paginated `get_fills` would require
+        dozens of round-trips. Calls `/fills/history/download/csv` and writes the
+        raw CSV to `output_path`. Returns `{path, row_count, size_bytes}`.
+
+        The output path is restricted to the current working directory or the user's
+        home directory to keep the write scope predictable.
+        """
+        resolved = _safe_export_path(output_path)
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        data = await client.get_raw(
+            "/fills/history/download/csv",
+            params={
+                "product_ids": _csv_ints(product_ids),
+                "contract_types": _csv(contract_types),
+                "start_time": start_time_us,
+                "end_time": end_time_us,
+            },
+            auth=True,
+        )
+        resolved.write_bytes(data)
+        # Row count = newline-delimited rows minus header. Be lenient if the response
+        # is empty or missing a trailing newline.
+        row_count = max(0, data.count(b"\n") - 1) if data else 0
+        return {
+            "path": str(resolved),
+            "row_count": row_count,
+            "size_bytes": len(data),
+        }

--- a/src/delta_exchange_mcp/tools/account.py
+++ b/src/delta_exchange_mcp/tools/account.py
@@ -22,6 +22,66 @@ def _csv_ints(values: list[int] | None) -> str | None:
     return ",".join(str(v) for v in values)
 
 
+_OPTION_CONTRACT_TYPES = {"call_options", "put_options"}
+
+
+def _is_option(pos: dict[str, Any]) -> bool:
+    ctype = pos.get("contract_type")
+    if not ctype and isinstance(pos.get("product"), dict):
+        ctype = pos["product"].get("contract_type")
+    if ctype in _OPTION_CONTRACT_TYPES:
+        return True
+    symbol = pos.get("product_symbol") or ""
+    return isinstance(symbol, str) and (symbol.startswith("C-") or symbol.startswith("P-"))
+
+
+def _lookup_contract_value(pos: dict[str, Any]) -> float | None:
+    raw = pos.get("contract_value")
+    if raw is None and isinstance(pos.get("product"), dict):
+        raw = pos["product"].get("contract_value")
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _patch_short_option_pnl(result: Any) -> Any:
+    """Server returns unsigned `unrealized_pnl` (premium value) for short options.
+    Recompute the signed P&L for those positions; leave others untouched.
+
+    Reason: upstream bug — for short option positions the API returns
+    mark_price * |size| * contract_value (premium value), ignoring the position
+    direction. Futures and long options are unaffected. See GH #9.
+    """
+    if not isinstance(result, dict):
+        return result
+    positions = result.get("result")
+    if not isinstance(positions, list):
+        return result
+    for pos in positions:
+        if not isinstance(pos, dict) or not _is_option(pos):
+            continue
+        size_raw = pos.get("size")
+        try:
+            size = int(size_raw)
+        except (TypeError, ValueError):
+            continue
+        if size >= 0:
+            continue
+        try:
+            entry = float(pos["entry_price"])
+            mark = float(pos["mark_price"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        contract_value = _lookup_contract_value(pos)
+        if contract_value is None:
+            continue
+        pos["unrealized_pnl"] = str((mark - entry) * size * contract_value)
+    return result
+
+
 def register(mcp: FastMCP, client: DeltaClient) -> None:
     @mcp.tool()
     async def get_positions(
@@ -65,8 +125,14 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
         get by multiplying the premium.
 
         `size` is signed: positive = long, negative = short.
+
+        Note on `unrealized_pnl` for short options: the upstream API returns
+        the absolute premium value (unsigned) rather than the signed mark-to-market
+        P&L. This tool patches the field client-side using
+        (mark_price - entry_price) * size * contract_value, with `size` signed.
+        Long options and futures pass through unchanged. See GH #9.
         """
-        return await client.get(
+        result = await client.get(
             "/positions/margined",
             params={
                 "product_ids": _csv_ints(product_ids),
@@ -74,6 +140,7 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
             },
             auth=True,
         )
+        return _patch_short_option_pnl(result)
 
     @mcp.tool()
     async def get_wallet_balances() -> dict[str, Any]:

--- a/src/delta_exchange_mcp/tools/market.py
+++ b/src/delta_exchange_mcp/tools/market.py
@@ -96,10 +96,79 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
         start: int = Field(description="Unix timestamp in seconds, inclusive."),
         end: int = Field(description="Unix timestamp in seconds, inclusive."),
     ) -> dict[str, Any]:
-        """OHLC candles. For funding/mark/OI history prefix the symbol: FUNDING:BTCUSD, MARK:BTCUSD, OI:BTCUSD."""
+        """OHLC candles. For funding/mark/OI history prefer the dedicated tools
+        get_funding_history / get_mark_price_history / get_oi_history (or prefix the
+        symbol manually: FUNDING:BTCUSD, MARK:BTCUSD, OI:BTCUSD).
+        """
         return await client.get(
             "/history/candles",
             params={"symbol": symbol, "resolution": resolution, "start": start, "end": end},
+        )
+
+    @mcp.tool()
+    async def get_funding_history(
+        symbol: str = Field(description="Perpetual symbol, e.g. BTCUSD or ETHUSD."),
+        resolution: Resolution = "1h",
+        start: int = Field(description="Unix timestamp in seconds, inclusive."),
+        end: int = Field(description="Unix timestamp in seconds, inclusive."),
+    ) -> dict[str, Any]:
+        """Historical funding rate candles for a perpetual.
+
+        Use this for basis-trade analysis, computing realized funding over a holding
+        period, or spotting funding-rate extremes. Returns OHLC over the funding rate.
+        """
+        return await client.get(
+            "/history/candles",
+            params={
+                "symbol": f"FUNDING:{symbol}",
+                "resolution": resolution,
+                "start": start,
+                "end": end,
+            },
+        )
+
+    @mcp.tool()
+    async def get_mark_price_history(
+        symbol: str = Field(description="Product symbol, e.g. BTCUSD or C-BTC-66400-010824."),
+        resolution: Resolution = "1m",
+        start: int = Field(description="Unix timestamp in seconds, inclusive."),
+        end: int = Field(description="Unix timestamp in seconds, inclusive."),
+    ) -> dict[str, Any]:
+        """Historical mark-price candles for a product.
+
+        Useful for reconstructing P&L curves, slippage checks against mark, or
+        comparing your fill price to fair value across an interval.
+        """
+        return await client.get(
+            "/history/candles",
+            params={
+                "symbol": f"MARK:{symbol}",
+                "resolution": resolution,
+                "start": start,
+                "end": end,
+            },
+        )
+
+    @mcp.tool()
+    async def get_oi_history(
+        symbol: str = Field(description="Product symbol, e.g. BTCUSD or ETHUSD."),
+        resolution: Resolution = "1h",
+        start: int = Field(description="Unix timestamp in seconds, inclusive."),
+        end: int = Field(description="Unix timestamp in seconds, inclusive."),
+    ) -> dict[str, Any]:
+        """Historical open-interest candles for a product.
+
+        Use to detect positioning extremes, squeeze risk, or OI build-up around
+        events. Returns OHLC over open interest.
+        """
+        return await client.get(
+            "/history/candles",
+            params={
+                "symbol": f"OI:{symbol}",
+                "resolution": resolution,
+                "start": start,
+                "end": end,
+            },
         )
 
     @mcp.tool()
@@ -118,8 +187,25 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
         )
 
     @mcp.tool()
+    async def get_indices() -> dict[str, Any]:
+        """Spot price indices that Delta builds by combining prices from prominent exchanges.
+
+        These indices underlie Delta's futures and options. Each index returns its
+        constituent exchanges + weights, `index_type` (spot_pair / fixed_interest_rate /
+        floating_interest_rate), tick_size, and the underlying/quoting asset.
+
+        Use when you need to understand how a product's mark or settlement price is
+        constructed, audit settlement composition, or assess outage/concentration risk
+        from a single constituent exchange.
+        """
+        return await client.get("/indices")
+
+    @mcp.tool()
     async def get_reference_data() -> dict[str, Any]:
-        """Merged assets + indices listing — useful for symbol/asset metadata lookups."""
+        """Merged assets + indices listing — useful for symbol/asset metadata lookups.
+
+        For index-only queries (composition, weights, index_type) prefer get_indices.
+        """
         assets = await client.get("/assets")
         indices = await client.get("/indices")
         return {"assets": assets, "indices": indices}

--- a/src/delta_exchange_mcp/tools/market.py
+++ b/src/delta_exchange_mcp/tools/market.py
@@ -106,6 +106,35 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
         )
 
     @mcp.tool()
+    async def get_settlement_prices(
+        contract_types: list[str] | None = Field(
+            default=None,
+            description="Filter expired products by contract type (e.g. call_options, put_options, futures).",
+        ),
+        page_size: int = Field(default=100, ge=1, le=500),
+        after: str | None = Field(default=None, description="Cursor from previous response's meta.after."),
+    ) -> dict[str, Any]:
+        """Historical settlement prices for expired/settled derivatives.
+
+        Use for post-expiry P&L reconciliation, backtesting against realized
+        settlements, or trade journaling. Each product object in the response carries
+        the settlement details (settlement_time, settlement_price) alongside the
+        product metadata. Returns paginated result + meta cursors.
+
+        Under the hood this is `list_products(states=["expired"])` — Delta exposes
+        settlement data through the products endpoint rather than a dedicated path.
+        """
+        return await client.get(
+            "/products",
+            params={
+                "contract_types": _csv(contract_types),
+                "states": "expired",
+                "page_size": page_size,
+                "after": after,
+            },
+        )
+
+    @mcp.tool()
     async def get_funding_history(
         symbol: str = Field(description="Perpetual symbol, e.g. BTCUSD or ETHUSD."),
         resolution: Resolution = "1h",

--- a/tests/test_account_tools.py
+++ b/tests/test_account_tools.py
@@ -17,6 +17,7 @@ from mcp.server.fastmcp import FastMCP
 from delta_exchange_mcp.client import DeltaClient
 from delta_exchange_mcp.config import INDIA_TESTNET_REST, Config
 from delta_exchange_mcp.tools import account
+from delta_exchange_mcp.tools.account import _patch_short_option_pnl
 
 
 def _client() -> DeltaClient:
@@ -210,3 +211,120 @@ async def test_get_profile():
     route = respx.get(f"{INDIA_TESTNET_REST}/profile").mock(return_value=_ok())
     await _call_tool("get_profile")
     assert route.called
+
+
+# --- GH #9: short-option unrealized_pnl sign fix ---------------------------
+
+
+def _short_call_buggy() -> dict[str, Any]:
+    # Matches the example response in GH #9 (C-BTC-78500-050626 short 10).
+    return {
+        "product_symbol": "C-BTC-78500-050626",
+        "contract_type": "call_options",
+        "size": -10,
+        "entry_price": "1529",
+        "mark_price": "1533.26",
+        "contract_value": "0.001",
+        "unrealized_pnl": "15.41",
+    }
+
+
+def _short_put_buggy() -> dict[str, Any]:
+    return {
+        "product_symbol": "P-BTC-70000-050626",
+        "contract_type": "put_options",
+        "size": -5,
+        "entry_price": "800",
+        "mark_price": "820",
+        "contract_value": "0.001",
+        "unrealized_pnl": "4.10",
+    }
+
+
+def _long_call_pristine() -> dict[str, Any]:
+    return {
+        "product_symbol": "C-BTC-78500-050626",
+        "contract_type": "call_options",
+        "size": 5,
+        "entry_price": "1529",
+        "mark_price": "1533.26",
+        "contract_value": "0.001",
+        "unrealized_pnl": "0.02",  # already signed for longs
+    }
+
+
+def _short_future_pristine() -> dict[str, Any]:
+    return {
+        "product_symbol": "BTCUSD",
+        "contract_type": "perpetual_futures",
+        "size": -10,
+        "entry_price": "77444",
+        "mark_price": "77432.79",
+        "contract_value": "0.001",
+        "unrealized_pnl": "0.11",  # futures already correct upstream
+    }
+
+
+def test_patch_short_call_overwrites_pnl():
+    out = _patch_short_option_pnl({"result": [_short_call_buggy()]})
+    pnl = float(out["result"][0]["unrealized_pnl"])
+    # (1533.26 - 1529) * -10 * 0.001 = -0.0426
+    assert pnl == pytest.approx(-0.0426, abs=1e-6)
+
+
+def test_patch_short_put_overwrites_pnl():
+    out = _patch_short_option_pnl({"result": [_short_put_buggy()]})
+    pnl = float(out["result"][0]["unrealized_pnl"])
+    # (820 - 800) * -5 * 0.001 = -0.1
+    assert pnl == pytest.approx(-0.1, abs=1e-6)
+
+
+def test_patch_leaves_long_option_untouched():
+    out = _patch_short_option_pnl({"result": [_long_call_pristine()]})
+    assert out["result"][0]["unrealized_pnl"] == "0.02"
+
+
+def test_patch_leaves_short_future_untouched():
+    out = _patch_short_option_pnl({"result": [_short_future_pristine()]})
+    assert out["result"][0]["unrealized_pnl"] == "0.11"
+
+
+def test_patch_skips_when_contract_value_missing():
+    pos = _short_call_buggy()
+    del pos["contract_value"]
+    out = _patch_short_option_pnl({"result": [pos]})
+    # Untouched because we can't compute signed pnl without contract_value.
+    assert out["result"][0]["unrealized_pnl"] == "15.41"
+
+
+def test_patch_detects_option_via_product_symbol_prefix():
+    # contract_type missing but product_symbol starts with C- — should still patch.
+    pos = _short_call_buggy()
+    del pos["contract_type"]
+    out = _patch_short_option_pnl({"result": [pos]})
+    pnl = float(out["result"][0]["unrealized_pnl"])
+    assert pnl == pytest.approx(-0.0426, abs=1e-6)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_margined_positions_patches_short_option_pnl():
+    """End-to-end: tool call returns patched response."""
+    respx.get(f"{INDIA_TESTNET_REST}/positions/margined").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "success": True,
+                "result": [_short_call_buggy(), _short_future_pristine()],
+            },
+        )
+    )
+    result = await _call_tool("get_margined_positions")
+    # FastMCP returns (content, structured) — the structured dict is what we want.
+    structured = result[1] if isinstance(result, tuple) else result
+    positions = structured["result"] if isinstance(structured, dict) else None
+    assert positions is not None, f"unexpected tool result shape: {result!r}"
+    short_call = next(p for p in positions if p["product_symbol"].startswith("C-"))
+    short_future = next(p for p in positions if p["product_symbol"] == "BTCUSD")
+    assert float(short_call["unrealized_pnl"]) == pytest.approx(-0.0426, abs=1e-6)
+    assert short_future["unrealized_pnl"] == "0.11"

--- a/tests/test_account_tools.py
+++ b/tests/test_account_tools.py
@@ -7,6 +7,7 @@ the MCP server, and asserts the request URL + query string + auth headers.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -17,7 +18,7 @@ from mcp.server.fastmcp import FastMCP
 from delta_exchange_mcp.client import DeltaClient
 from delta_exchange_mcp.config import INDIA_TESTNET_REST, Config
 from delta_exchange_mcp.tools import account
-from delta_exchange_mcp.tools.account import _patch_short_option_pnl
+from delta_exchange_mcp.tools.account import _patch_short_option_pnl, _safe_export_path
 
 
 def _client() -> DeltaClient:
@@ -213,6 +214,32 @@ async def test_get_profile():
     assert route.called
 
 
+# --- GH #6: bulk_fills_export ----------------------------------------------
+
+
+def test_safe_export_path_accepts_cwd_relative(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    assert _safe_export_path("fills.csv") == (tmp_path / "fills.csv").resolve()
+
+
+def test_safe_export_path_accepts_home_tilde():
+    assert _safe_export_path("~/fills.csv") == (Path.home() / "fills.csv").resolve()
+
+
+def test_safe_export_path_rejects_outside_scope(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError, match="must be inside"):
+        _safe_export_path("/etc/passwd")
+
+
+def test_safe_export_path_rejects_dotdot_traversal(tmp_path, monkeypatch):
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    monkeypatch.chdir(sandbox)
+    with pytest.raises(ValueError, match="must be inside"):
+        _safe_export_path("../../../../etc/passwd")
+
+
 # --- GH #9: short-option unrealized_pnl sign fix ---------------------------
 
 
@@ -304,6 +331,64 @@ def test_patch_detects_option_via_product_symbol_prefix():
     out = _patch_short_option_pnl({"result": [pos]})
     pnl = float(out["result"][0]["unrealized_pnl"])
     assert pnl == pytest.approx(-0.0426, abs=1e-6)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_bulk_fills_export_writes_csv(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    csv_body = b"id,size,price\n1,10,77000\n2,-5,77100\n"
+    respx.get(f"{INDIA_TESTNET_REST}/fills/history/download/csv").mock(
+        return_value=httpx.Response(
+            200, content=csv_body, headers={"content-type": "text/csv"}
+        )
+    )
+    result = await _call_tool(
+        "bulk_fills_export",
+        output_path="fills.csv",
+        start_time_us=1000,
+        end_time_us=2000,
+        product_ids=[1, 2],
+    )
+    structured = result[1] if isinstance(result, tuple) else result
+    assert (tmp_path / "fills.csv").read_bytes() == csv_body
+    assert structured["row_count"] == 2
+    assert structured["size_bytes"] == len(csv_body)
+    assert structured["path"].endswith("fills.csv")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_bulk_fills_export_passes_query_params(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    route = respx.get(f"{INDIA_TESTNET_REST}/fills/history/download/csv").mock(
+        return_value=httpx.Response(200, content=b"a,b\n", headers={"content-type": "text/csv"})
+    )
+    await _call_tool(
+        "bulk_fills_export",
+        output_path="fills.csv",
+        product_ids=[1, 2],
+        contract_types=["perpetual_futures"],
+        start_time_us=100,
+        end_time_us=200,
+    )
+    url = str(route.calls[0].request.url)
+    assert "product_ids=1%2C2" in url
+    assert "contract_types=perpetual_futures" in url
+    assert "start_time=100" in url
+    assert "end_time=200" in url
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_bulk_fills_export_rejects_unsafe_path(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    route = respx.get(f"{INDIA_TESTNET_REST}/fills/history/download/csv").mock(
+        return_value=httpx.Response(200, content=b"")
+    )
+    with pytest.raises(Exception):
+        await _call_tool("bulk_fills_export", output_path="/etc/passwd")
+    assert not route.called
 
 
 @pytest.mark.asyncio

--- a/tests/test_market_tools.py
+++ b/tests/test_market_tools.py
@@ -1,9 +1,13 @@
+from typing import Any
+
 import httpx
 import pytest
 import respx
+from mcp.server.fastmcp import FastMCP
 
 from delta_exchange_mcp.client import DeltaClient
 from delta_exchange_mcp.config import INDIA_TESTNET_REST, Config
+from delta_exchange_mcp.tools import market
 
 
 @pytest.fixture
@@ -62,6 +66,82 @@ async def test_none_params_are_stripped_before_send(client: DeltaClient):
     assert "contract_types" not in sent
     assert "states=live" in sent
     assert "page_size=3" in sent
+
+
+async def _call_market_tool(client: DeltaClient, name: str, **kwargs: Any) -> Any:
+    mcp = FastMCP("test")
+    market.register(mcp, client)
+    return await mcp.call_tool(name, kwargs)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_indices_hits_indices_endpoint(client: DeltaClient):
+    route = respx.get(f"{INDIA_TESTNET_REST}/indices").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": []})
+    )
+    await _call_market_tool(client, "get_indices")
+    assert route.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_funding_history_prefixes_symbol(client: DeltaClient):
+    route = respx.get(f"{INDIA_TESTNET_REST}/history/candles").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": []})
+    )
+    await _call_market_tool(
+        client, "get_funding_history", symbol="BTCUSD", resolution="1h", start=1, end=2
+    )
+    url = str(route.calls[0].request.url)
+    assert "symbol=FUNDING%3ABTCUSD" in url
+    assert "resolution=1h" in url
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_mark_price_history_prefixes_symbol(client: DeltaClient):
+    route = respx.get(f"{INDIA_TESTNET_REST}/history/candles").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": []})
+    )
+    await _call_market_tool(
+        client,
+        "get_mark_price_history",
+        symbol="C-BTC-66400-010824",
+        resolution="5m",
+        start=1,
+        end=2,
+    )
+    url = str(route.calls[0].request.url)
+    assert "symbol=MARK%3AC-BTC-66400-010824" in url
+    assert "resolution=5m" in url
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_oi_history_prefixes_symbol(client: DeltaClient):
+    route = respx.get(f"{INDIA_TESTNET_REST}/history/candles").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": []})
+    )
+    await _call_market_tool(
+        client, "get_oi_history", symbol="ETHUSD", resolution="1h", start=1, end=2
+    )
+    url = str(route.calls[0].request.url)
+    assert "symbol=OI%3AETHUSD" in url
+
+
+def test_new_history_tools_are_registered(client: DeltaClient):
+    import asyncio
+
+    mcp = FastMCP("test")
+    market.register(mcp, client)
+    names = {t.name for t in asyncio.run(mcp.list_tools())}
+    assert {
+        "get_indices",
+        "get_funding_history",
+        "get_mark_price_history",
+        "get_oi_history",
+    }.issubset(names)
 
 
 @pytest.mark.asyncio

--- a/tests/test_market_tools.py
+++ b/tests/test_market_tools.py
@@ -76,6 +76,28 @@ async def _call_market_tool(client: DeltaClient, name: str, **kwargs: Any) -> An
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_get_settlement_prices_filters_states_expired(client: DeltaClient):
+    route = respx.get(f"{INDIA_TESTNET_REST}/products").mock(
+        return_value=httpx.Response(
+            200, json={"success": True, "result": [], "meta": {"after": None}}
+        )
+    )
+    await _call_market_tool(
+        client,
+        "get_settlement_prices",
+        contract_types=["call_options", "put_options"],
+        page_size=50,
+        after="cur",
+    )
+    url = str(route.calls[0].request.url)
+    assert "states=expired" in url
+    assert "contract_types=call_options%2Cput_options" in url
+    assert "page_size=50" in url
+    assert "after=cur" in url
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_get_indices_hits_indices_endpoint(client: DeltaClient):
     route = respx.get(f"{INDIA_TESTNET_REST}/indices").mock(
         return_value=httpx.Response(200, json={"success": True, "result": []})


### PR DESCRIPTION
Promotes the five merged PRs from develop to main for the v0.2.0 release.

## Included
- #11 Clarify account tool docstrings (#3, #7, #10)
- #13 README per-client install matrix + dev-branch install section
- #14 Patch short-option unrealized_pnl client-side (#9)
- #15 Add get_indices and history wrapper tools (#5, #8)
- #16 Add get_settlement_prices and bulk_fills_export tools (#4, #6)

Testing completed on testing/issues-3-10. 59 tests pass, ruff clean.