### PR TITLE
fix: surface API's default ~90-day window on wallet/fills history (#18)

### DIFF
--- a/src/delta_exchange_mcp/tools/account.py
+++ b/src/delta_exchange_mcp/tools/account.py
@@ -11,6 +11,25 @@ from pydantic import Field
 from delta_exchange_mcp.client import DeltaClient
 
 
+_RECENT_WINDOW_NOTICE = (
+    "No start_time_us was given, so the API returned only its default recent window "
+    "(~90 days). Older records are NOT included. To get full history, call again with "
+    "an explicit start_time_us (microseconds epoch)."
+)
+
+
+def _annotate_default_window(result: dict[str, Any], start_time_us: int | None) -> dict[str, Any]:
+    """Flag results that silently used the API's ~90-day default window.
+
+    When the caller omits start_time_us the upstream API only returns the last ~90 days, so a
+    short/empty result must not be read as "nothing exists" (see GH #18). Mutates only dict
+    responses; no-op when start_time_us was provided.
+    """
+    if start_time_us is None and isinstance(result, dict):
+        result["notice"] = _RECENT_WINDOW_NOTICE
+    return result
+
+
 def _csv(values: list[str] | None) -> str | None:
     if not values:
         return None
@@ -178,16 +197,31 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
         asset_ids: list[int] | None = Field(default=None, description="Filter by asset ids."),
         transaction_types: list[str] | None = Field(
             default=None,
-            description="Filter by transaction type (e.g. deposit, withdrawal, funding, settlement, commission).",
+            description=(
+                "Filter by transaction type (e.g. deposit, withdrawal, funding, settlement, "
+                "commission). Note: sparse/older types like deposit and liquidation_fee may sit "
+                "outside the default ~90-day window — pass start_time_us to find them."
+            ),
         ),
-        start_time_us: int | None = Field(default=None, description="Microseconds epoch."),
+        start_time_us: int | None = Field(
+            default=None,
+            description=(
+                "Window start, microseconds epoch. If omitted the API returns only the last "
+                "~90 days; set this to reach older history."
+            ),
+        ),
         end_time_us: int | None = None,
         page_size: int = Field(default=50, ge=1, le=200),
         after: str | None = None,
         before: str | None = None,
     ) -> dict[str, Any]:
-        """Wallet transaction history. Paginated. Timestamps are microseconds."""
-        return await client.get(
+        """Wallet transaction history. Paginated. Timestamps are microseconds.
+
+        If start_time_us is omitted the API returns only the last ~90 days — pass start_time_us
+        for older/full history (e.g. all deposits, tax/reconciliation). When omitted, the result
+        carries a `notice` field saying so.
+        """
+        result = await client.get(
             "/wallet/transactions",
             params={
                 "asset_ids": _csv_ints(asset_ids),
@@ -200,18 +234,29 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
             },
             auth=True,
         )
+        return _annotate_default_window(result, start_time_us)
 
     @mcp.tool()
     async def get_fills(
         product_ids: list[int] | None = None,
         contract_types: list[str] | None = None,
-        start_time_us: int | None = Field(default=None, description="Microseconds epoch."),
+        start_time_us: int | None = Field(
+            default=None,
+            description=(
+                "Window start, microseconds epoch. If omitted the API returns only the last "
+                "~90 days; set this to reach older fills."
+            ),
+        ),
         end_time_us: int | None = None,
         page_size: int = Field(default=50, ge=1, le=200),
         after: str | None = None,
     ) -> dict[str, Any]:
-        """Your trade fills (executed trades). Paginated. Timestamps are microseconds."""
-        return await client.get(
+        """Your trade fills (executed trades). Paginated. Timestamps are microseconds.
+
+        If start_time_us is omitted the API returns only the last ~90 days — pass start_time_us
+        for older/full history. When omitted, the result carries a `notice` field saying so.
+        """
+        result = await client.get(
             "/fills",
             params={
                 "product_ids": _csv_ints(product_ids),
@@ -223,6 +268,7 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
             },
             auth=True,
         )
+        return _annotate_default_window(result, start_time_us)
 
     @mcp.tool()
     async def get_open_orders(
@@ -331,6 +377,10 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
         dozens of round-trips. Calls `/fills/history/download/csv` and writes the
         raw CSV to `output_path`. Returns `{path, row_count, size_bytes}`.
 
+        IMPORTANT: if start_time_us is omitted the API exports only the last ~90 days —
+        a tax/full-history export MUST pass start_time_us (and usually end_time_us) or it
+        will silently miss older trades. When omitted, the result carries a `notice` field.
+
         The output path is restricted to the current working directory or the user's
         home directory to keep the write scope predictable.
         """
@@ -350,8 +400,11 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
         # Row count = newline-delimited rows minus header. Be lenient if the response
         # is empty or missing a trailing newline.
         row_count = max(0, data.count(b"\n") - 1) if data else 0
-        return {
-            "path": str(resolved),
-            "row_count": row_count,
-            "size_bytes": len(data),
-        }
+        return _annotate_default_window(
+            {
+                "path": str(resolved),
+                "row_count": row_count,
+                "size_bytes": len(data),
+            },
+            start_time_us,
+        )

--- a/tests/test_account_tools.py
+++ b/tests/test_account_tools.py
@@ -91,6 +91,56 @@ async def test_get_wallet_transactions_csv_and_pagination():
     assert "after=cur" in url
 
 
+# --- GH #18: default ~90-day window notice -------------------------------
+
+
+def _structured(result: Any) -> Any:
+    return result[1] if isinstance(result, tuple) else result
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_wallet_transactions_notice_when_start_time_omitted():
+    respx.get(f"{INDIA_TESTNET_REST}/wallet/transactions").mock(
+        return_value=_ok({"success": True, "result": [], "meta": {"total_count": 0}})
+    )
+    result = await _call_tool("get_wallet_transactions", transaction_types=["deposit"])
+    assert "~90 days" in _structured(result)["notice"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_wallet_transactions_no_notice_when_start_time_given():
+    respx.get(f"{INDIA_TESTNET_REST}/wallet/transactions").mock(
+        return_value=_ok({"success": True, "result": [], "meta": {"total_count": 0}})
+    )
+    result = await _call_tool("get_wallet_transactions", start_time_us=1000)
+    assert "notice" not in _structured(result)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_fills_notice_when_start_time_omitted():
+    respx.get(f"{INDIA_TESTNET_REST}/fills").mock(return_value=_ok())
+    result = await _call_tool("get_fills")
+    assert "notice" in _structured(result)
+    result2 = await _call_tool("get_fills", start_time_us=1000)
+    assert "notice" not in _structured(result2)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_bulk_fills_export_notice_when_start_time_omitted(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    respx.get(f"{INDIA_TESTNET_REST}/fills/history/download/csv").mock(
+        return_value=httpx.Response(200, content=b"a,b\n1,2\n", headers={"content-type": "text/csv"})
+    )
+    result = await _call_tool("bulk_fills_export", output_path="fills.csv")
+    structured = _structured(result)
+    assert "notice" in structured
+    assert structured["row_count"] == 1  # notice doesn't disturb the real fields
+
+
 @pytest.mark.asyncio
 @respx.mock
 async def test_get_positions_requires_one_param():


### PR DESCRIPTION
## Why

[Issue #18](https://github.com/delta-exchange/delta-exchange-mcp/issues/18) looked like the `transaction_types=["deposit"]` filter was broken (returns `total_count: 0` while deposits exist). Live probing of the API proved the real cause: **the backend silently defaults `start_time` to ~90 days ago when it is omitted.** Sparse/older records (deposits, liquidation fees) fall outside that window and return empty, so an assistant asked "show my deposits" with no time range reports "no deposits" on an account that has them - dangerous for accounting/tax/reconciliation.

Verified live:
- The `deposit` filter works inside an explicit window (no filter bug).
- Default triggers specifically when `start_time` is omitted (passing it alone returns full history).
- No max-range cap - `epoch -> now` is accepted, so full history just needs an explicit `start_time`.
- Same truncation confirmed on `/wallet/transactions` (1 -> 5), `/fills` (33 -> 76), and the CSV export (33 -> 76 rows).

## What

- `_annotate_default_window`: when `start_time_us` is omitted, attach a `notice` to the result so the model doesn't read a short/empty response as "none exist".
- Applied to `get_wallet_transactions`, `get_fills`, `bulk_fills_export` (the CSV export's tax/full-history purpose makes the silent cap most dangerous there).
- Docstrings + `start_time_us` / `transaction_types` descriptions now state the ~90-day default and that `start_time_us` is required for older/full history.
- Faithful approach - no silent request change. (Auto-widening was rejected: unfiltered wide queries returned `504` in probing.)

## Excluded

`get_order_history` - its time filter behaves anomalously upstream (a wide `start_time` returns *fewer* rows than no range). Raised separately with the platform team, not fixed here.

## Tests

`uv run pytest` green; `ruff` clean. New tests assert the `notice` is present when `start_time_us` is omitted and absent when provided, across all three tools.