### PR TITLE
Release v0.3.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,19 @@ Each tool module exposes `register(mcp: FastMCP, client: DeltaClient) -> None` t
 
 There's no future v2 "trade" gate yet; when that lands, add a `DELTA_MCP_MODE=trade` flag and a `tools/trading.py` register call gated on `(has_credentials and mode == "trade")`. The signer + auth plumbing is already in place.
 
+### Debug logging
+
+`debug_log.py` exposes `configure(cfg) -> Path | None`, called from `build_server`. When
+`DELTA_MCP_DEBUG` is truthy it attaches a `FileHandler` to the `delta_exchange_mcp` and `httpx`
+loggers (INFO, `propagate=False`, **never** `logging.basicConfig`) so request URLs + response
+bodies land in `~/.delta-exchange-mcp/logs/debug-<ts>-<pid>.log`. `client.py` emits the `→`/`←`/`✗`
+lines. **Invariant: credentials (api-key / api_secret / signature / timestamp) are never logged** —
+only headers carry them and we never log the headers dict. Regression test:
+`test_logs_request_and_body_but_no_secrets`. The module is deliberately **not** named `logging.py`
+(would shadow the stdlib `logging` import). `server.py` registers a `get_debug_status` tool (only
+when debug is on) so the assistant can report the log path; the path is also in the stderr startup
+banner.
+
 ### Environment naming
 
 `DELTA_MCP_ENV` values are `india_prod` / `india_testnet` (not `mainnet`/`testnet`) to match Delta's own URL naming (`api.india.delta.exchange`, `cdn-ind.testnet.deltaex.org`). `india_prod` is the default — users ask "what's BTCUSD mid", they mean prod, not testnet.

--- a/README.md
+++ b/README.md
@@ -263,6 +263,32 @@ New tools appear only after the respawn. The MCP `list_changed` notification ref
 | `DELTA_MCP_ENV` | `india_prod` | `india_prod` or `india_testnet`. |
 | `DELTA_API_KEY` | _(unset)_ | API key. Optional; when set with `DELTA_API_SECRET`, account tools register. |
 | `DELTA_API_SECRET` | _(unset)_ | API secret matching `DELTA_API_KEY`. |
+| `DELTA_MCP_DEBUG` | _(unset)_ | `1`/`true`/`yes`/`on` writes HTTP request URLs and response bodies to a log file (see [Debugging](#debugging--reporting-a-bug)). |
+| `DELTA_MCP_DEBUG_FILE` | _(auto)_ | Override the debug log path. Default: `~/.delta-exchange-mcp/logs/debug-<timestamp>-<pid>.log`. |
+
+## Debugging / reporting a bug
+
+To capture exactly what the server sends and receives — useful when a tool returns
+something unexpected — set `DELTA_MCP_DEBUG=1` in your MCP client config:
+
+```jsonc
+"delta-exchange": {
+  "command": "uvx",
+  "args": ["delta-exchange-mcp"],
+  "env": {
+    "DELTA_MCP_ENV": "india_prod",
+    "DELTA_MCP_DEBUG": "1"
+  }
+}
+```
+
+Restart the client and re-run the action. Each HTTP call (request URL incl. filter params +
+response body + status) is logged to `~/.delta-exchange-mcp/logs/`. The exact path is printed
+on startup and you can also just **ask the assistant: _"where is the debug log?"_** (the
+`get_debug_status` tool returns it).
+
+> The log **never** contains your API key, secret, or request signatures — but response bodies
+> **do** contain your account data (balances, positions, transactions). **Review before sharing.**
 
 ## Tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "delta-exchange-mcp"
-version = "0.2.0"
+version = "0.3.0"
 description = "Official MCP server for Delta Exchange India — market data and account read for AI assistants."
 readme = "README.md"
 authors = [

--- a/src/delta_exchange_mcp/client.py
+++ b/src/delta_exchange_mcp/client.py
@@ -119,11 +119,20 @@ class DeltaClient:
                 continue
 
             if raw:
-                logger.info(
-                    "← %s %s %s content-type=%s bytes=%s",
-                    method, path, resp.status_code,
-                    resp.headers.get("content-type", ""), len(resp.content),
-                )
+                ctype = resp.headers.get("content-type", "")
+                # Log a capped textual body for text/CSV/JSON so a bad export (e.g. the
+                # /fills/history/download/csv account export) leaves usable wire evidence;
+                # only fall back to byte-count for genuinely binary payloads.
+                if any(t in ctype.lower() for t in ("text", "csv", "json")):
+                    logger.info(
+                        "← %s %s %s content-type=%s body=%s",
+                        method, path, resp.status_code, ctype, resp.text[:_BODY_LOG_CAP],
+                    )
+                else:
+                    logger.info(
+                        "← %s %s %s content-type=%s bytes=%s",
+                        method, path, resp.status_code, ctype, len(resp.content),
+                    )
             else:
                 logger.info(
                     "← %s %s %s body=%s", method, path, resp.status_code, resp.text[:_BODY_LOG_CAP]

--- a/src/delta_exchange_mcp/client.py
+++ b/src/delta_exchange_mcp/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import hmac
+import logging
 import time
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
@@ -12,6 +13,11 @@ import httpx
 
 from delta_exchange_mcp.config import Config
 from delta_exchange_mcp.errors import DeltaApiError
+
+logger = logging.getLogger("delta_exchange_mcp")
+
+# Cap on how much of a response body we log, so a huge paginated payload can't bloat the file.
+_BODY_LOG_CAP = 50_000
 
 try:
     USER_AGENT = f"delta-exchange-mcp/{version('delta-exchange-mcp')}"
@@ -88,6 +94,10 @@ class DeltaClient:
             headers["signature"] = signature
             headers["timestamp"] = ts
 
+        logger.info(
+            "→ %s %s params=%s auth=%s", method, f"{self._base_path}{path}", filtered_params, auth
+        )
+
         last_error: Exception | None = None
         for attempt in range(3):
             try:
@@ -108,7 +118,21 @@ class DeltaClient:
                 await asyncio.sleep(0.5 * (2**attempt))
                 continue
 
-            return self._unwrap_raw(resp) if raw else self._unwrap(resp)
+            if raw:
+                logger.info(
+                    "← %s %s %s content-type=%s bytes=%s",
+                    method, path, resp.status_code,
+                    resp.headers.get("content-type", ""), len(resp.content),
+                )
+            else:
+                logger.info(
+                    "← %s %s %s body=%s", method, path, resp.status_code, resp.text[:_BODY_LOG_CAP]
+                )
+            try:
+                return self._unwrap_raw(resp) if raw else self._unwrap(resp)
+            except DeltaApiError as e:
+                logger.info("✗ %s %s code=%s status=%s", method, path, e.code, e.status)
+                raise
 
         assert last_error is not None
         raise last_error

--- a/src/delta_exchange_mcp/config.py
+++ b/src/delta_exchange_mcp/config.py
@@ -17,12 +17,16 @@ BASE_URLS: dict[str, str] = {
 DEFAULT_ENV = "india_prod"
 
 
+TRUTHY = {"1", "true", "yes", "on"}
+
+
 @dataclass(frozen=True)
 class Config:
     env: Env
     base_url: str
     api_key: str | None = None
     api_secret: str | None = None
+    debug: bool = False
 
     @property
     def has_credentials(self) -> bool:
@@ -41,4 +45,5 @@ def load() -> Config:
         base_url=BASE_URLS[env],
         api_key=os.environ.get("DELTA_API_KEY") or None,
         api_secret=os.environ.get("DELTA_API_SECRET") or None,
+        debug=os.environ.get("DELTA_MCP_DEBUG", "").strip().lower() in TRUTHY,
     )

--- a/src/delta_exchange_mcp/debug_log.py
+++ b/src/delta_exchange_mcp/debug_log.py
@@ -36,15 +36,27 @@ def _resolve_path() -> Path:
     return Path.home() / ".delta-exchange-mcp" / "logs" / name
 
 
+def _make_handler(path: Path) -> logging.FileHandler:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handler = logging.FileHandler(path, encoding="utf-8")
+    # Owner read/write only — the log may contain account data (balances, fills,
+    # transactions). FileHandler creates the file empty under the process umask
+    # (often 644), so tighten before any body is written. Best-effort: no-op on
+    # platforms without POSIX permissions (e.g. Windows).
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+    return handler
+
+
 def _open_handler(path: Path) -> tuple[logging.FileHandler, Path]:
     """Create the dir and a FileHandler, falling back to a tempdir on OSError."""
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        return logging.FileHandler(path, encoding="utf-8"), path
+        return _make_handler(path), path
     except OSError:
         fallback = Path(tempfile.gettempdir()) / "delta-exchange-mcp" / path.name
-        fallback.parent.mkdir(parents=True, exist_ok=True)
-        return logging.FileHandler(fallback, encoding="utf-8"), fallback
+        return _make_handler(fallback), fallback
 
 
 def configure(cfg: Config) -> Path | None:

--- a/src/delta_exchange_mcp/debug_log.py
+++ b/src/delta_exchange_mcp/debug_log.py
@@ -1,0 +1,85 @@
+"""Opt-in file logging for `DELTA_MCP_DEBUG`.
+
+When enabled, HTTP request URLs (incl. filter params) and response bodies are written to a
+file so a user on a vanilla `uvx` install can capture wire-level evidence for a bug report.
+Credentials (api-key / api_secret / signature / timestamp) are NEVER logged; response bodies
+may contain account data, so the file is "review before sharing", not "always safe to share".
+
+NB: this module is intentionally NOT named `logging.py` — that would shadow the stdlib
+`logging` module on `import logging` elsewhere in the package.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import tempfile
+import time
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+from delta_exchange_mcp.config import Config
+
+LOGGER_NAMES = ("delta_exchange_mcp", "httpx")
+_FORMAT = "%(asctime)s %(name)s %(levelname)s %(message)s"
+# Marker so we don't attach a second handler if build_server runs twice in one process.
+_MARKER = "_delta_debug_handler"
+
+
+def _resolve_path() -> Path:
+    override = os.environ.get("DELTA_MCP_DEBUG_FILE")
+    if override:
+        return Path(override).expanduser()
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    name = f"debug-{stamp}-{os.getpid()}.log"
+    return Path.home() / ".delta-exchange-mcp" / "logs" / name
+
+
+def _open_handler(path: Path) -> tuple[logging.FileHandler, Path]:
+    """Create the dir and a FileHandler, falling back to a tempdir on OSError."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return logging.FileHandler(path, encoding="utf-8"), path
+    except OSError:
+        fallback = Path(tempfile.gettempdir()) / "delta-exchange-mcp" / path.name
+        fallback.parent.mkdir(parents=True, exist_ok=True)
+        return logging.FileHandler(fallback, encoding="utf-8"), fallback
+
+
+def configure(cfg: Config) -> Path | None:
+    """Attach a file log handler when debug is on. Idempotent. Returns the path or None."""
+    if not cfg.debug:
+        return None
+
+    root = logging.getLogger(LOGGER_NAMES[0])
+    for h in root.handlers:
+        if getattr(h, _MARKER, False):
+            return Path(h.baseFilename)  # already configured this process
+
+    try:
+        handler, path = _open_handler(_resolve_path())
+    except OSError as e:
+        print(f"[delta-exchange-mcp] debug logging disabled: {e}", file=sys.stderr)
+        return None
+
+    setattr(handler, _MARKER, True)
+    handler.setFormatter(logging.Formatter(_FORMAT))
+    for name in LOGGER_NAMES:
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        logger.propagate = False  # never leak to a root/stdout handler
+
+    try:
+        pkg_version = version("delta-exchange-mcp")
+    except PackageNotFoundError:
+        pkg_version = "0+unknown"
+    surface = "market+account" if cfg.has_credentials else "market"
+    logging.getLogger(LOGGER_NAMES[0]).info(
+        "debug log start: delta-exchange-mcp/%s env=%s base_url=%s surface=%s | "
+        "credentials (api-key/secret/signature) are never logged; "
+        "response bodies may contain account data",
+        pkg_version, cfg.env, cfg.base_url, surface,
+    )
+    return path

--- a/src/delta_exchange_mcp/server.py
+++ b/src/delta_exchange_mcp/server.py
@@ -41,6 +41,7 @@ def main() -> None:
     banner = f"[delta-exchange-mcp] stdio env={cfg.env} base_url={cfg.base_url} surface={surface}"
     if cfg.debug:
         log_path = debug_log.configure(cfg)  # idempotent — returns the same path
-        banner += f" debug=on log={log_path}"
+        if log_path is not None:  # configure returns None if the log file can't be opened
+            banner += f" debug=on log={log_path}"
     print(banner, file=sys.stderr)
     mcp.run()

--- a/src/delta_exchange_mcp/server.py
+++ b/src/delta_exchange_mcp/server.py
@@ -5,6 +5,7 @@ import sys
 from mcp.server.fastmcp import FastMCP
 
 from delta_exchange_mcp import config as config_mod
+from delta_exchange_mcp import debug_log
 from delta_exchange_mcp.client import DeltaClient
 from delta_exchange_mcp.tools import account, market
 
@@ -14,9 +15,22 @@ def build_server(cfg: config_mod.Config | None = None) -> FastMCP:
     mcp = FastMCP("delta-exchange")
     client = DeltaClient(cfg)
 
+    log_path = debug_log.configure(cfg)
+
     market.register(mcp, client)
     if cfg.has_credentials:
         account.register(mcp, client)
+
+    if log_path is not None:
+
+        @mcp.tool()
+        def get_debug_status() -> dict[str, object]:
+            """Whether debug logging is on and the absolute path of the current log file.
+
+            Use this to tell the user where to find / fetch the HTTP debug log.
+            """
+            return {"enabled": True, "log_path": str(log_path)}
+
     return mcp
 
 
@@ -24,8 +38,9 @@ def main() -> None:
     cfg = config_mod.load()
     mcp = build_server(cfg)
     surface = "market+account" if cfg.has_credentials else "market"
-    print(
-        f"[delta-exchange-mcp] stdio env={cfg.env} base_url={cfg.base_url} surface={surface}",
-        file=sys.stderr,
-    )
+    banner = f"[delta-exchange-mcp] stdio env={cfg.env} base_url={cfg.base_url} surface={surface}"
+    if cfg.debug:
+        log_path = debug_log.configure(cfg)  # idempotent — returns the same path
+        banner += f" debug=on log={log_path}"
+    print(banner, file=sys.stderr)
     mcp.run()

--- a/src/delta_exchange_mcp/tools/account.py
+++ b/src/delta_exchange_mcp/tools/account.py
@@ -11,6 +11,25 @@ from pydantic import Field
 from delta_exchange_mcp.client import DeltaClient
 
 
+_RECENT_WINDOW_NOTICE = (
+    "No start_time_us was given, so the API returned only its default recent window "
+    "(~90 days). Older records are NOT included. To get full history, call again with "
+    "an explicit start_time_us (microseconds epoch)."
+)
+
+
+def _annotate_default_window(result: dict[str, Any], start_time_us: int | None) -> dict[str, Any]:
+    """Flag results that silently used the API's ~90-day default window.
+
+    When the caller omits start_time_us the upstream API only returns the last ~90 days, so a
+    short/empty result must not be read as "nothing exists" (see GH #18). Mutates only dict
+    responses; no-op when start_time_us was provided.
+    """
+    if start_time_us is None and isinstance(result, dict):
+        result["notice"] = _RECENT_WINDOW_NOTICE
+    return result
+
+
 def _csv(values: list[str] | None) -> str | None:
     if not values:
         return None
@@ -178,16 +197,31 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
         asset_ids: list[int] | None = Field(default=None, description="Filter by asset ids."),
         transaction_types: list[str] | None = Field(
             default=None,
-            description="Filter by transaction type (e.g. deposit, withdrawal, funding, settlement, commission).",
+            description=(
+                "Filter by transaction type (e.g. deposit, withdrawal, funding, settlement, "
+                "commission). Note: sparse/older types like deposit and liquidation_fee may sit "
+                "outside the default ~90-day window — pass start_time_us to find them."
+            ),
         ),
-        start_time_us: int | None = Field(default=None, description="Microseconds epoch."),
+        start_time_us: int | None = Field(
+            default=None,
+            description=(
+                "Window start, microseconds epoch. If omitted the API returns only the last "
+                "~90 days; set this to reach older history."
+            ),
+        ),
         end_time_us: int | None = None,
         page_size: int = Field(default=50, ge=1, le=200),
         after: str | None = None,
         before: str | None = None,
     ) -> dict[str, Any]:
-        """Wallet transaction history. Paginated. Timestamps are microseconds."""
-        return await client.get(
+        """Wallet transaction history. Paginated. Timestamps are microseconds.
+
+        If start_time_us is omitted the API returns only the last ~90 days — pass start_time_us
+        for older/full history (e.g. all deposits, tax/reconciliation). When omitted, the result
+        carries a `notice` field saying so.
+        """
+        result = await client.get(
             "/wallet/transactions",
             params={
                 "asset_ids": _csv_ints(asset_ids),
@@ -200,18 +234,29 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
             },
             auth=True,
         )
+        return _annotate_default_window(result, start_time_us)
 
     @mcp.tool()
     async def get_fills(
         product_ids: list[int] | None = None,
         contract_types: list[str] | None = None,
-        start_time_us: int | None = Field(default=None, description="Microseconds epoch."),
+        start_time_us: int | None = Field(
+            default=None,
+            description=(
+                "Window start, microseconds epoch. If omitted the API returns only the last "
+                "~90 days; set this to reach older fills."
+            ),
+        ),
         end_time_us: int | None = None,
         page_size: int = Field(default=50, ge=1, le=200),
         after: str | None = None,
     ) -> dict[str, Any]:
-        """Your trade fills (executed trades). Paginated. Timestamps are microseconds."""
-        return await client.get(
+        """Your trade fills (executed trades). Paginated. Timestamps are microseconds.
+
+        If start_time_us is omitted the API returns only the last ~90 days — pass start_time_us
+        for older/full history. When omitted, the result carries a `notice` field saying so.
+        """
+        result = await client.get(
             "/fills",
             params={
                 "product_ids": _csv_ints(product_ids),
@@ -223,6 +268,7 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
             },
             auth=True,
         )
+        return _annotate_default_window(result, start_time_us)
 
     @mcp.tool()
     async def get_open_orders(
@@ -331,6 +377,10 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
         dozens of round-trips. Calls `/fills/history/download/csv` and writes the
         raw CSV to `output_path`. Returns `{path, row_count, size_bytes}`.
 
+        IMPORTANT: if start_time_us is omitted the API exports only the last ~90 days —
+        a tax/full-history export MUST pass start_time_us (and usually end_time_us) or it
+        will silently miss older trades. When omitted, the result carries a `notice` field.
+
         The output path is restricted to the current working directory or the user's
         home directory to keep the write scope predictable.
         """
@@ -350,8 +400,11 @@ def register(mcp: FastMCP, client: DeltaClient) -> None:
         # Row count = newline-delimited rows minus header. Be lenient if the response
         # is empty or missing a trailing newline.
         row_count = max(0, data.count(b"\n") - 1) if data else 0
-        return {
-            "path": str(resolved),
-            "row_count": row_count,
-            "size_bytes": len(data),
-        }
+        return _annotate_default_window(
+            {
+                "path": str(resolved),
+                "row_count": row_count,
+                "size_bytes": len(data),
+            },
+            start_time_us,
+        )

--- a/tests/test_account_tools.py
+++ b/tests/test_account_tools.py
@@ -91,6 +91,56 @@ async def test_get_wallet_transactions_csv_and_pagination():
     assert "after=cur" in url
 
 
+# --- GH #18: default ~90-day window notice -------------------------------
+
+
+def _structured(result: Any) -> Any:
+    return result[1] if isinstance(result, tuple) else result
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_wallet_transactions_notice_when_start_time_omitted():
+    respx.get(f"{INDIA_TESTNET_REST}/wallet/transactions").mock(
+        return_value=_ok({"success": True, "result": [], "meta": {"total_count": 0}})
+    )
+    result = await _call_tool("get_wallet_transactions", transaction_types=["deposit"])
+    assert "~90 days" in _structured(result)["notice"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_wallet_transactions_no_notice_when_start_time_given():
+    respx.get(f"{INDIA_TESTNET_REST}/wallet/transactions").mock(
+        return_value=_ok({"success": True, "result": [], "meta": {"total_count": 0}})
+    )
+    result = await _call_tool("get_wallet_transactions", start_time_us=1000)
+    assert "notice" not in _structured(result)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_fills_notice_when_start_time_omitted():
+    respx.get(f"{INDIA_TESTNET_REST}/fills").mock(return_value=_ok())
+    result = await _call_tool("get_fills")
+    assert "notice" in _structured(result)
+    result2 = await _call_tool("get_fills", start_time_us=1000)
+    assert "notice" not in _structured(result2)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_bulk_fills_export_notice_when_start_time_omitted(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    respx.get(f"{INDIA_TESTNET_REST}/fills/history/download/csv").mock(
+        return_value=httpx.Response(200, content=b"a,b\n1,2\n", headers={"content-type": "text/csv"})
+    )
+    result = await _call_tool("bulk_fills_export", output_path="fills.csv")
+    structured = _structured(result)
+    assert "notice" in structured
+    assert structured["row_count"] == 1  # notice doesn't disturb the real fields
+
+
 @pytest.mark.asyncio
 @respx.mock
 async def test_get_positions_requires_one_param():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,3 +40,20 @@ def test_partial_credentials_do_not_count(monkeypatch):
     monkeypatch.delenv("DELTA_API_SECRET", raising=False)
     cfg = config_mod.load()
     assert cfg.has_credentials is False
+
+
+def test_debug_off_by_default(monkeypatch):
+    monkeypatch.delenv("DELTA_MCP_DEBUG", raising=False)
+    assert config_mod.load().debug is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "ON", " True "])
+def test_debug_truthy_values(monkeypatch, value):
+    monkeypatch.setenv("DELTA_MCP_DEBUG", value)
+    assert config_mod.load().debug is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "", "no"])
+def test_debug_falsy_values(monkeypatch, value):
+    monkeypatch.setenv("DELTA_MCP_DEBUG", value)
+    assert config_mod.load().debug is False

--- a/tests/test_debug_log.py
+++ b/tests/test_debug_log.py
@@ -62,6 +62,28 @@ async def test_logs_request_and_body_but_no_secrets(tmp_path, monkeypatch):
     assert signature not in text
 
 
+@pytest.mark.asyncio
+@respx.mock
+async def test_logs_csv_body_for_raw_text_response(tmp_path, monkeypatch):
+    log_file = tmp_path / "d.log"
+    monkeypatch.setenv("DELTA_MCP_DEBUG_FILE", str(log_file))
+    cfg = _cfg(tmp_path, api_key="k", api_secret="s", debug=True)
+    debug_log.configure(cfg)
+
+    csv_body = b"Time,Contract,Side\n2026-01-01,BTCUSD,buy\n"
+    respx.get(f"{INDIA_TESTNET_REST}/fills/history/download/csv").mock(
+        return_value=httpx.Response(200, content=csv_body, headers={"content-type": "text/csv"})
+    )
+    client = DeltaClient(cfg)
+    await client.get_raw("/fills/history/download/csv", auth=True)
+    await client.aclose()
+
+    for h in logging.getLogger("delta_exchange_mcp").handlers:
+        h.flush()
+    text = log_file.read_text()
+    assert "Time,Contract,Side" in text  # raw CSV body captured, not just byte count
+
+
 def test_debug_off_returns_none(tmp_path, monkeypatch):
     monkeypatch.setenv("DELTA_MCP_DEBUG_FILE", str(tmp_path / "d.log"))
     assert debug_log.configure(_cfg(tmp_path, debug=False)) is None

--- a/tests/test_debug_log.py
+++ b/tests/test_debug_log.py
@@ -88,3 +88,15 @@ def test_debug_off_returns_none(tmp_path, monkeypatch):
     monkeypatch.setenv("DELTA_MCP_DEBUG_FILE", str(tmp_path / "d.log"))
     assert debug_log.configure(_cfg(tmp_path, debug=False)) is None
     assert not (tmp_path / "d.log").exists()
+
+
+def test_log_file_is_owner_only(tmp_path, monkeypatch):
+    import os
+    import stat
+
+    if os.name == "nt":
+        pytest.skip("no POSIX file permissions on Windows")
+    log_file = tmp_path / "d.log"
+    monkeypatch.setenv("DELTA_MCP_DEBUG_FILE", str(log_file))
+    debug_log.configure(_cfg(tmp_path, api_key="k", api_secret="s", debug=True))
+    assert stat.S_IMODE(log_file.stat().st_mode) == 0o600

--- a/tests/test_debug_log.py
+++ b/tests/test_debug_log.py
@@ -1,0 +1,68 @@
+import logging
+
+import httpx
+import pytest
+import respx
+
+from delta_exchange_mcp import debug_log
+from delta_exchange_mcp.client import DeltaClient
+from delta_exchange_mcp.config import INDIA_TESTNET_REST, Config
+
+
+@pytest.fixture(autouse=True)
+def _clear_handlers():
+    """Each test attaches a FileHandler to module loggers; remove them after so the open
+    file doesn't leak into the next test (and the idempotency guard starts fresh)."""
+    yield
+    for name in debug_log.LOGGER_NAMES:
+        logger = logging.getLogger(name)
+        for h in list(logger.handlers):
+            h.close()
+            logger.removeHandler(h)
+        logger.setLevel(logging.NOTSET)
+        logger.propagate = True
+
+
+def _cfg(tmp_path, **kw):
+    return Config(env="india_testnet", base_url=INDIA_TESTNET_REST, **kw)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_logs_request_and_body_but_no_secrets(tmp_path, monkeypatch):
+    log_file = tmp_path / "d.log"
+    monkeypatch.setenv("DELTA_MCP_DEBUG_FILE", str(log_file))
+    cfg = _cfg(tmp_path, api_key="APIKEY123", api_secret="SUPERSECRET", debug=True)
+    path = debug_log.configure(cfg)
+    assert path == log_file
+
+    route = respx.get(f"{INDIA_TESTNET_REST}/wallet/transactions").mock(
+        return_value=httpx.Response(
+            200,
+            json={"success": True, "result": [{"transaction_type": "deposit"}], "meta": {"total_count": 3}},
+        )
+    )
+    client = DeltaClient(cfg)
+    await client.get("/wallet/transactions", params={"transaction_types": "deposit"}, auth=True)
+    await client.aclose()
+
+    for h in logging.getLogger("delta_exchange_mcp").handlers:
+        h.flush()
+    text = log_file.read_text()
+
+    # Request + body are captured.
+    assert "wallet/transactions" in text
+    assert "transaction_types=deposit" in text
+    assert "total_count" in text
+    assert "200" in text
+    # Credentials are never written.
+    assert "SUPERSECRET" not in text
+    assert "APIKEY123" not in text
+    signature = route.calls[0].request.headers["signature"]
+    assert signature not in text
+
+
+def test_debug_off_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("DELTA_MCP_DEBUG_FILE", str(tmp_path / "d.log"))
+    assert debug_log.configure(_cfg(tmp_path, debug=False)) is None
+    assert not (tmp_path / "d.log").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "delta-exchange-mcp"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Release v0.3.0 — brings develop to main.

## Features

- **Opt-in debug logging** (#19): `DELTA_MCP_DEBUG=1` writes HTTP request URLs (incl. filter params) and response bodies to `~/.delta-exchange-mcp/logs/debug-<ts>-<pid>.log`. New `get_debug_status` tool reports the log path; path also printed in the startup banner. API key/secret/signature are never logged. `DELTA_MCP_DEBUG_FILE` overrides the path.

## Fixes

- **Surface the API's default ~90-day window** (#20, closes #18): the backend silently defaults `start_time` to ~90 days when omitted, so historical/sparse queries (e.g. deposits) under-reported and looked like a broken `transaction_types` filter. `get_wallet_transactions`, `get_fills`, and `bulk_fills_export` now attach a `notice` when `start_time_us` is omitted, and their docstrings state that an explicit `start_time_us` is required for older/full history.

## Version

`pyproject.toml` + `uv.lock` bumped 0.2.0 → 0.3.0 (minor: new env vars/tool + behavior change).

After merge: tag `v0.3.0`, publish to PyPI, draft the GitHub release per RELEASING.md.