### PR TITLE
fix(debug): restrict debug log file to owner-only (0600)

### DIFF
--- a/src/delta_exchange_mcp/debug_log.py
+++ b/src/delta_exchange_mcp/debug_log.py
@@ -36,15 +36,27 @@ def _resolve_path() -> Path:
     return Path.home() / ".delta-exchange-mcp" / "logs" / name
 
 
+def _make_handler(path: Path) -> logging.FileHandler:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handler = logging.FileHandler(path, encoding="utf-8")
+    # Owner read/write only — the log may contain account data (balances, fills,
+    # transactions). FileHandler creates the file empty under the process umask
+    # (often 644), so tighten before any body is written. Best-effort: no-op on
+    # platforms without POSIX permissions (e.g. Windows).
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+    return handler
+
+
 def _open_handler(path: Path) -> tuple[logging.FileHandler, Path]:
     """Create the dir and a FileHandler, falling back to a tempdir on OSError."""
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        return logging.FileHandler(path, encoding="utf-8"), path
+        return _make_handler(path), path
     except OSError:
         fallback = Path(tempfile.gettempdir()) / "delta-exchange-mcp" / path.name
-        fallback.parent.mkdir(parents=True, exist_ok=True)
-        return logging.FileHandler(fallback, encoding="utf-8"), fallback
+        return _make_handler(fallback), fallback
 
 
 def configure(cfg: Config) -> Path | None:

--- a/tests/test_debug_log.py
+++ b/tests/test_debug_log.py
@@ -88,3 +88,15 @@ def test_debug_off_returns_none(tmp_path, monkeypatch):
     monkeypatch.setenv("DELTA_MCP_DEBUG_FILE", str(tmp_path / "d.log"))
     assert debug_log.configure(_cfg(tmp_path, debug=False)) is None
     assert not (tmp_path / "d.log").exists()
+
+
+def test_log_file_is_owner_only(tmp_path, monkeypatch):
+    import os
+    import stat
+
+    if os.name == "nt":
+        pytest.skip("no POSIX file permissions on Windows")
+    log_file = tmp_path / "d.log"
+    monkeypatch.setenv("DELTA_MCP_DEBUG_FILE", str(log_file))
+    debug_log.configure(_cfg(tmp_path, api_key="k", api_secret="s", debug=True))
+    assert stat.S_IMODE(log_file.stat().st_mode) == 0o600


### PR DESCRIPTION
Greptile security finding on the v0.3.0 release PR (#21).

`logging.FileHandler` creates the debug log under the process umask (often `644` on Linux/macOS), and the file intentionally contains account data (wallet balances, fills, transactions). On a shared host another local user could read it.

Fix: `chmod 0o600` immediately after the file is created (it's empty at that point, before any body is written). Best-effort — no-op on platforms without POSIX permissions (Windows). Regression test asserts mode `0600` on POSIX.