### PR TITLE
Release v0.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project in one line
 
-FastMCP server (stdio only) that wraps Delta Exchange India's REST API as MCP tools — public market data unconditionally, plus authenticated read-only account tools when `DELTA_API_KEY`/`DELTA_API_SECRET` are set.
+FastMCP server (stdio only) that wraps Delta Exchange India's REST API as MCP tools — public market data unconditionally, authenticated read-only account tools when `DELTA_API_KEY`/`DELTA_API_SECRET` are set, plus authenticated trading mutations when `DELTA_MCP_MODE=trade` is also set.
 
 ## Style
 
@@ -51,7 +51,8 @@ Each tool module exposes `register(mcp: FastMCP, client: DeltaClient) -> None` t
 2. **Retry policy** — 429 backs off using the `X-RATE-LIMIT-RESET` header (ms); 5xx uses exponential backoff. Only retries GET; POST/PUT/DELETE never auto-retry.
 3. **Error-envelope unwrapping** — `{success: false, error: {code, context}}` is raised as `DeltaApiError` (see `errors.py`). `errors.py` carries a hint table for documented auth codes (`SignatureExpired`, `InvalidApiKey`, `UnauthorizedApiAccess`, `ip_not_whitelisted_for_api_key`, `Signature Mismatch`) and extracts the request IP from the error context for the IP-whitelist case.
 4. **HMAC-SHA256 signing** — `sign()` concatenates `method + timestamp + path + query + body`. The signing path **must include the `/v2` prefix** per Delta's spec; the client derives it once from `urlparse(base_url).path` and prepends it before calling `sign()`. Don't pass `path="/v2/..."` from callers — they pass relative paths like `/orders`, the client adds the prefix.
-5. **User-Agent header is required by Delta** — a missing one returns 403. Do not remove it.
+5. **Body signing (POST/PUT/DELETE)** — the signed `body` must be the **exact bytes sent on the wire**. `_request` serializes `json_body` once with `json.dumps(..., separators=(",", ":"))`, signs that string, and sends the **same** string via `httpx.request(content=...)`. Do **not** switch back to `json=json_body` — httpx would re-serialize with different spacing and the signature would mismatch. Same "compute once, feed both" rule as None-param stripping (#1). Regression test: `test_place_order_signs_exact_body_bytes`. Convenience methods: `post()` / `put()` / `delete()`.
+6. **User-Agent header is required by Delta** — a missing one returns 403. Do not remove it.
 
 ### Auth surface registration
 
@@ -59,7 +60,19 @@ Each tool module exposes `register(mcp: FastMCP, client: DeltaClient) -> None` t
 
 `server.build_server()` registers them only when both creds are present. Without creds, the server runs in pure-public mode — same behaviour as before this surface existed.
 
-There's no future v2 "trade" gate yet; when that lands, add a `DELTA_MCP_MODE=trade` flag and a `tools/trading.py` register call gated on `(has_credentials and mode == "trade")`. The signer + auth plumbing is already in place.
+### Trading surface (mutations)
+
+`tools/trading.py` exposes 13 authenticated write tools (place/edit/cancel order, cancel-all, place/edit/cancel batch, place/edit bracket, set-leverage, change-margin, close-all, auto-topup). Its `register(mcp, client, audit)` is gated on `(cfg.has_credentials and cfg.mode == "trade")` in `build_server`; `DELTA_MCP_MODE` defaults to `read`, so the surface is off unless explicitly opted into.
+
+Conventions in `trading.py`:
+- Every mutating tool takes `dry_run: bool`. The shared `_finish(tool, method, path, payload, dry_run)` helper strips `None` keys, and when `dry_run` returns `{dry_run, method, path, payload}` **without** any HTTP call; otherwise it sends via `client.post/put/delete` and records to the audit log on both success and `DeltaApiError`.
+- Order-level boolean flags (`post_only`, `reduce_only`, `cancel_*`) are Delta **string enums** — convert with `_bs()` to `"true"`/`"false"`. Position-level flags (`auto_topup`, `close_all_*`) are real JSON booleans.
+- `close_all_positions` needs `user_id`; it is auto-resolved from `/profile` once and cached per-process in the `register` closure — never a tool param.
+- Batch tools cap at `_MAX_BATCH = 50`.
+
+### Audit logging
+
+`audit_log.py` exposes `configure(cfg) -> AuditLog | None` (returns `None` unless `mode == "trade"`; `DELTA_MCP_AUDIT=off|false|0|no` is a kill switch). `AuditLog.record(...)` appends one JSON line per mutation to `~/.delta-exchange-mcp/audit/audit-<ts>-<pid>.log`, created `0600`. **Invariant: no credentials** — only the request body (which carries none) and a summarized result are recorded. `configure` caches a single `_INSTANCE` per process so `build_server` and `main`'s banner share one file. `server.py` registers `get_trading_status` (trade mode only) to report `{mode, audit_log_path}`. Regression test: `test_audit_records_success_and_error_without_secrets`.
 
 ### Debug logging
 
@@ -79,6 +92,8 @@ banner.
 `DELTA_MCP_ENV` values are `india_prod` / `india_testnet` (not `mainnet`/`testnet`) to match Delta's own URL naming (`api.india.delta.exchange`, `cdn-ind.testnet.deltaex.org`). `india_prod` is the default — users ask "what's BTCUSD mid", they mean prod, not testnet.
 
 API keys are env-scoped on Delta's side: prod keys created at delta.exchange only work against `india_prod`; demo keys at demo.delta.exchange only work against `india_testnet`. Mismatch → `InvalidApiKey`.
+
+`DELTA_MCP_MODE` is `read` (default) or `trade`; only `trade` registers `tools/trading.py`. `DELTA_MCP_AUDIT` (kill switch) and `DELTA_MCP_AUDIT_FILE` (path override) govern the audit log.
 
 ## Reference — Delta Exchange API
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ New tools appear only after the respawn. The MCP `list_changed` notification ref
 
 | Var | Default | Purpose |
 |---|---|---|
-| `DELTA_MCP_ENV` | `india_prod` | `india_prod` or `india_testnet`. |
+| `DELTA_MCP_ENV` | `india_prod` | `india_prod`, `india_testnet`, or `india_devnet`. |
 | `DELTA_API_KEY` | _(unset)_ | API key. Optional; when set with `DELTA_API_SECRET`, account tools register. |
 | `DELTA_API_SECRET` | _(unset)_ | API secret matching `DELTA_API_KEY`. |
 | `DELTA_MCP_MODE` | `read` | `trade` registers the trading tools (requires API key + secret). Default `read` is read-only. See [Trading](#trading-opt-in). |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Official MCP (Model Context Protocol) server for **Delta Exchange India**. Lets 
 
 > **Status:** Beta. Functional and used internally, but the tool surface and configuration may still change. Please [open an issue](https://github.com/delta-exchange/delta-exchange-mcp/issues) for bugs, missing tools, or rough edges. Early reports directly shape what ships next.
 
-**What you get:** 9 public market-data tools + 12 authenticated read-only account tools (positions, orders, fills, wallet, stats, leverage, preferences, profile). **No mutations.** The server cannot place, edit, or cancel orders.
+**What you get:** 9 public market-data tools + 12 authenticated read-only account tools (positions, orders, fills, wallet, stats, leverage, preferences, profile). Trading mutations (place / edit / cancel orders, brackets, leverage, margin, close-all) are available but **off by default** — they register only when you opt in with `DELTA_MCP_MODE=trade` (see [Trading](#trading-opt-in)).
 
 ---
 
@@ -263,8 +263,11 @@ New tools appear only after the respawn. The MCP `list_changed` notification ref
 | `DELTA_MCP_ENV` | `india_prod` | `india_prod` or `india_testnet`. |
 | `DELTA_API_KEY` | _(unset)_ | API key. Optional; when set with `DELTA_API_SECRET`, account tools register. |
 | `DELTA_API_SECRET` | _(unset)_ | API secret matching `DELTA_API_KEY`. |
+| `DELTA_MCP_MODE` | `read` | `trade` registers the trading tools (requires API key + secret). Default `read` is read-only. See [Trading](#trading-opt-in). |
 | `DELTA_MCP_DEBUG` | _(unset)_ | `1`/`true`/`yes`/`on` writes HTTP request URLs and response bodies to a log file (see [Debugging](#debugging--reporting-a-bug)). |
 | `DELTA_MCP_DEBUG_FILE` | _(auto)_ | Override the debug log path. Default: `~/.delta-exchange-mcp/logs/debug-<timestamp>-<pid>.log`. |
+| `DELTA_MCP_AUDIT` | _(on in trade mode)_ | Set `off`/`false`/`0`/`no` to disable the trading audit log. On by default whenever `DELTA_MCP_MODE=trade`. |
+| `DELTA_MCP_AUDIT_FILE` | _(auto)_ | Override the audit log path. Default: `~/.delta-exchange-mcp/audit/audit-<timestamp>-<pid>.log`. |
 
 ## Debugging / reporting a bug
 
@@ -315,6 +318,43 @@ on startup and you can also just **ask the assistant: _"where is the debug log?"
 | `get_product_leverage` | Per-product leverage setting. |
 | `get_trading_stats` / `get_trading_preferences` / `get_profile` | Account-level stats, preferences, profile. |
 
+### Trading (opt-in)
+
+Trading tools register **only** when `DELTA_MCP_MODE=trade` is set alongside valid credentials. Without it the server stays read-only.
+
+| Tool | Action |
+|---|---|
+| `place_order` / `edit_order` / `cancel_order` | Single limit/market/stop order lifecycle. |
+| `cancel_all_orders` | Cancel open orders (optionally filtered by product / contract type). |
+| `place_batch_orders` / `edit_batch_orders` / `cancel_batch_orders` | Up to 50 orders on one contract per request. |
+| `place_bracket_order` / `edit_bracket_order` | Attach / edit a take-profit + stop-loss bracket. |
+| `set_product_leverage` | Set order leverage for a product. |
+| `adjust_position_margin` | Add / remove isolated margin on a position. |
+| `close_all_positions` | Close all open positions (your `user_id` is resolved automatically from your profile). |
+| `configure_auto_topup` | Toggle per-position auto top-up. |
+
+Enable it in your client config:
+
+```jsonc
+"delta-exchange": {
+  "command": "uvx",
+  "args": ["delta-exchange-mcp"],
+  "env": {
+    "DELTA_MCP_ENV": "india_prod",
+    "DELTA_API_KEY": "your-api-key",
+    "DELTA_API_SECRET": "your-api-secret",
+    "DELTA_MCP_MODE": "trade"
+  }
+}
+```
+
+Safety features:
+
+- **Dry run.** Every mutating tool takes a `dry_run` flag. When `true`, the tool validates and returns the exact payload it *would* send, without sending it. Ask the assistant to "place the order as a dry run first."
+- **Audit log.** Every mutation (real or dry-run) is appended as one JSON line to `~/.delta-exchange-mcp/audit/` (owner-only `0600`). On by default in trade mode; disable with `DELTA_MCP_AUDIT=off`. The log records the tool, params, and result/order id — **never** credentials. Ask the assistant "where is the audit log?" (the `get_trading_status` tool returns the path).
+- **No silent retries.** Unlike GET reads, mutations are never auto-retried on timeout or rate-limit — a failure is surfaced, not re-sent.
+- **API key permission.** The key must have Trading enabled in Delta API management, and the requesting IP whitelisted.
+
 ## Example prompts
 
 Once connected, you can ask things like:
@@ -356,8 +396,8 @@ Maintainers: see [`RELEASING.md`](RELEASING.md) for the release procedure.
 
 ## Roadmap
 
-- **Now**: 9 public market-data + 12 authenticated read-only account tools.
-- **Next**: trading mutations (place / edit / cancel / close, leverage change) gated behind an explicit `DELTA_MCP_MODE=trade` flag, with an audit log and basic guardrails.
+- **Now**: 9 public market-data + 12 authenticated read-only account tools + 13 trading tools (opt-in via `DELTA_MCP_MODE=trade`, with dry-run and an audit log).
+- **Next**: richer guardrails (notional / position-size caps, confirmation prompts).
 
 ## Feedback & issues
 
@@ -374,6 +414,7 @@ Please redact `api_key` / `api_secret` from any logs or screenshots before attac
 
 ## Safety
 
-- **No mutations.** Every tool is GET. The server cannot place, edit, or cancel orders.
+- **Read-only by default.** Trading tools register only with the explicit `DELTA_MCP_MODE=trade` opt-in; otherwise every tool is a GET and the server cannot place, edit, or cancel orders.
+- **Auditable mutations.** When trading is on, every mutation is dry-runnable and written to an owner-only audit log; mutations are never auto-retried.
 - **Local stdio only.** Per-user keys never leave your machine; no shared hosted endpoint.
 - **Read the code.** It's a financial-tool MCP; treat it like one.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "delta-exchange-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "Official MCP server for Delta Exchange India — market data and account read for AI assistants."
 readme = "README.md"
 authors = [

--- a/src/delta_exchange_mcp/audit_log.py
+++ b/src/delta_exchange_mcp/audit_log.py
@@ -1,0 +1,122 @@
+"""Append-only audit log for trading mutations (`DELTA_MCP_MODE=trade`).
+
+Every mutating tool call — including dry-runs — is recorded as one JSON line so the user
+has a durable record of what the assistant placed, edited, cancelled or closed. Request
+bodies carry NO credentials (api-key / secret / signature live only in HTTP headers, which
+are never written here), so the recorded params are safe; they may still reference order
+ids and sizes, so the file is created owner-only (0600).
+
+This module is separate from `debug_log.py`: debug logging is opt-in wire tracing, the audit
+log is an always-on safety record whenever trading is enabled.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from delta_exchange_mcp.config import Config
+
+
+def _resolve_path() -> Path:
+    override = os.environ.get("DELTA_MCP_AUDIT_FILE")
+    if override:
+        return Path(override).expanduser()
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    name = f"audit-{stamp}-{os.getpid()}.log"
+    return Path.home() / ".delta-exchange-mcp" / "audit" / name
+
+
+class AuditLog:
+    def __init__(self, path: Path, env: str):
+        self.path = path
+        self._env = env
+
+    def record(
+        self,
+        tool: str,
+        params: dict[str, Any],
+        *,
+        result: Any = None,
+        error: str | None = None,
+        dry_run: bool = False,
+    ) -> None:
+        """Append one JSON line describing a mutation attempt. Best-effort; never raises."""
+        entry: dict[str, Any] = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "env": self._env,
+            "tool": tool,
+            "dry_run": dry_run,
+            "params": params,
+        }
+        if error is not None:
+            entry["error"] = error
+        elif result is not None:
+            entry["result"] = _summarize(result)
+        try:
+            with self.path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(entry, default=str) + "\n")
+        except OSError as e:
+            print(f"[delta-exchange-mcp] audit write failed: {e}", file=sys.stderr)
+
+
+def _summarize(result: Any) -> Any:
+    """Keep the audit line compact: pull the order id/state out of a Delta result envelope."""
+    if isinstance(result, dict):
+        inner = result.get("result", result)
+        if isinstance(inner, dict):
+            return {k: inner[k] for k in ("id", "state", "client_order_id") if k in inner} or inner
+    return result
+
+
+# Explicit kill switch: the audit log is ON by default in trade mode, but a user who
+# really doesn't want a file on disk can set DELTA_MCP_AUDIT to one of these.
+_DISABLE = {"off", "false", "0", "no"}
+
+# One audit file per process — build_server and main() both call configure(); cache so
+# they share the same file (the resolved path uses a timestamp that would otherwise drift).
+_INSTANCE: AuditLog | None = None
+
+
+def configure(cfg: Config) -> AuditLog | None:
+    """Create the audit log file when trading is enabled. Returns the AuditLog or None.
+
+    On by default in trade mode; DELTA_MCP_AUDIT=off|false|0|no disables it. Idempotent
+    within a process.
+    """
+    global _INSTANCE
+    if cfg.mode != "trade":
+        return None
+    if os.environ.get("DELTA_MCP_AUDIT", "").strip().lower() in _DISABLE:
+        return None
+    if _INSTANCE is not None:
+        return _INSTANCE
+
+    path = _resolve_path()
+    try:
+        path = _open(path)
+    except OSError:
+        fallback = Path(tempfile.gettempdir()) / "delta-exchange-mcp" / path.name
+        try:
+            path = _open(fallback)
+        except OSError as e:
+            print(f"[delta-exchange-mcp] audit logging disabled: {e}", file=sys.stderr)
+            return None
+    _INSTANCE = AuditLog(path, cfg.env)
+    return _INSTANCE
+
+
+def _open(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Create empty + tighten to owner-only before any entry is written (umask is often 0644).
+    path.touch(exist_ok=True)
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+    return path

--- a/src/delta_exchange_mcp/client.py
+++ b/src/delta_exchange_mcp/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import hmac
+import json
 import logging
 import time
 from importlib.metadata import PackageNotFoundError, version
@@ -61,6 +62,15 @@ class DeltaClient:
         """
         return await self._request("GET", path, params=params, auth=auth, raw=True)
 
+    async def post(self, path: str, json_body: Any = None, *, auth: bool = False) -> Any:
+        return await self._request("POST", path, json_body=json_body, auth=auth)
+
+    async def put(self, path: str, json_body: Any = None, *, auth: bool = False) -> Any:
+        return await self._request("PUT", path, json_body=json_body, auth=auth)
+
+    async def delete(self, path: str, json_body: Any = None, *, auth: bool = False) -> Any:
+        return await self._request("DELETE", path, json_body=json_body, auth=auth)
+
     async def _request(
         self,
         method: str,
@@ -72,7 +82,16 @@ class DeltaClient:
         raw: bool = False,
     ) -> Any:
         headers: dict[str, str] = {}
-        body_str = ""  # TODO when POST lands in v2
+        # Delta signs the EXACT request body bytes. Serialize once (compact, no spaces) and
+        # feed the same string to both sign() and httpx via content= — using json= would let
+        # httpx re-serialize with different spacing and break the signature. Mirrors the
+        # "filter params once, feed both signing and the request" pattern below.
+        body_str = ""
+        content: bytes | None = None
+        if json_body is not None:
+            body_str = json.dumps(json_body, separators=(",", ":"))
+            content = body_str.encode()
+            headers["Content-Type"] = "application/json"
         query_str = ""
         filtered_params = {k: v for k, v in (params or {}).items() if v is not None} or None
         if filtered_params:
@@ -94,15 +113,17 @@ class DeltaClient:
             headers["signature"] = signature
             headers["timestamp"] = ts
 
+        # body_str carries no credentials (those live only in headers, never logged).
         logger.info(
-            "→ %s %s params=%s auth=%s", method, f"{self._base_path}{path}", filtered_params, auth
+            "→ %s %s params=%s auth=%s body=%s",
+            method, f"{self._base_path}{path}", filtered_params, auth, body_str[:_BODY_LOG_CAP],
         )
 
         last_error: Exception | None = None
         for attempt in range(3):
             try:
                 resp = await self._http.request(
-                    method, path, params=filtered_params, json=json_body, headers=headers
+                    method, path, params=filtered_params, content=content, headers=headers
                 )
             except httpx.HTTPError as e:
                 last_error = e

--- a/src/delta_exchange_mcp/config.py
+++ b/src/delta_exchange_mcp/config.py
@@ -4,15 +4,17 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
-Env = Literal["india_prod", "india_testnet"]
+Env = Literal["india_prod", "india_testnet", "india_devnet"]
 Mode = Literal["read", "trade"]
 
 INDIA_PROD_REST = "https://api.india.delta.exchange/v2"
 INDIA_TESTNET_REST = "https://cdn-ind.testnet.deltaex.org/v2"
+INDIA_DEVNET_REST = "https://cdn-ind.devnet.deltaex.org/v2"
 
 BASE_URLS: dict[str, str] = {
     "india_prod": INDIA_PROD_REST,
     "india_testnet": INDIA_TESTNET_REST,
+    "india_devnet": INDIA_DEVNET_REST,
 }
 
 DEFAULT_ENV = "india_prod"

--- a/src/delta_exchange_mcp/config.py
+++ b/src/delta_exchange_mcp/config.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 Env = Literal["india_prod", "india_testnet"]
+Mode = Literal["read", "trade"]
 
 INDIA_PROD_REST = "https://api.india.delta.exchange/v2"
 INDIA_TESTNET_REST = "https://cdn-ind.testnet.deltaex.org/v2"
@@ -15,6 +16,8 @@ BASE_URLS: dict[str, str] = {
 }
 
 DEFAULT_ENV = "india_prod"
+DEFAULT_MODE = "read"
+MODES: set[str] = {"read", "trade"}
 
 
 TRUTHY = {"1", "true", "yes", "on"}
@@ -27,6 +30,7 @@ class Config:
     api_key: str | None = None
     api_secret: str | None = None
     debug: bool = False
+    mode: Mode = "read"
 
     @property
     def has_credentials(self) -> bool:
@@ -40,10 +44,15 @@ def load() -> Config:
             f"DELTA_MCP_ENV must be one of {sorted(BASE_URLS)}, got {env!r}"
         )
 
+    mode = os.environ.get("DELTA_MCP_MODE", DEFAULT_MODE).strip().lower()
+    if mode not in MODES:
+        raise ValueError(f"DELTA_MCP_MODE must be one of {sorted(MODES)}, got {mode!r}")
+
     return Config(
         env=env,  # type: ignore[arg-type]
         base_url=BASE_URLS[env],
         api_key=os.environ.get("DELTA_API_KEY") or None,
         api_secret=os.environ.get("DELTA_API_SECRET") or None,
         debug=os.environ.get("DELTA_MCP_DEBUG", "").strip().lower() in TRUTHY,
+        mode=mode,  # type: ignore[arg-type]
     )

--- a/src/delta_exchange_mcp/server.py
+++ b/src/delta_exchange_mcp/server.py
@@ -4,10 +4,11 @@ import sys
 
 from mcp.server.fastmcp import FastMCP
 
+from delta_exchange_mcp import audit_log
 from delta_exchange_mcp import config as config_mod
 from delta_exchange_mcp import debug_log
 from delta_exchange_mcp.client import DeltaClient
-from delta_exchange_mcp.tools import account, market
+from delta_exchange_mcp.tools import account, market, trading
 
 
 def build_server(cfg: config_mod.Config | None = None) -> FastMCP:
@@ -20,6 +21,22 @@ def build_server(cfg: config_mod.Config | None = None) -> FastMCP:
     market.register(mcp, client)
     if cfg.has_credentials:
         account.register(mcp, client)
+
+    trade_audit = None
+    if cfg.has_credentials and cfg.mode == "trade":
+        trade_audit = audit_log.configure(cfg)
+        trading.register(mcp, client, trade_audit)
+
+        @mcp.tool()
+        def get_trading_status() -> dict[str, object]:
+            """Trading mode status and the audit log path (None if auditing is disabled).
+
+            Use this to tell the user that mutations are enabled and where the audit log lives.
+            """
+            return {
+                "mode": cfg.mode,
+                "audit_log_path": str(trade_audit.path) if trade_audit else None,
+            }
 
     if log_path is not None:
 
@@ -38,7 +55,16 @@ def main() -> None:
     cfg = config_mod.load()
     mcp = build_server(cfg)
     surface = "market+account" if cfg.has_credentials else "market"
-    banner = f"[delta-exchange-mcp] stdio env={cfg.env} base_url={cfg.base_url} surface={surface}"
+    trade_on = cfg.has_credentials and cfg.mode == "trade"
+    if trade_on:
+        surface += "+trade"
+    banner = (
+        f"[delta-exchange-mcp] stdio env={cfg.env} base_url={cfg.base_url} "
+        f"mode={cfg.mode} surface={surface}"
+    )
+    if trade_on:
+        audit = audit_log.configure(cfg)  # idempotent: appends to the same file path
+        banner += f" audit={audit.path if audit else 'off'}"
     if cfg.debug:
         log_path = debug_log.configure(cfg)  # idempotent — returns the same path
         if log_path is not None:  # configure returns None if the log file can't be opened

--- a/src/delta_exchange_mcp/tools/trading.py
+++ b/src/delta_exchange_mcp/tools/trading.py
@@ -62,6 +62,44 @@ def _validate_order(order_type: str | None, limit_price: str | None, size: int |
         raise ValueError("market_order must not carry a limit_price (it is ignored, not a cap)")
 
 
+def _flag_partial(result: Any, sent: list[dict[str, Any]]) -> Any:
+    """Detect a batch partial failure and annotate the response (BUG-2).
+
+    Delta returns only the processed orders with no per-index error, so we compare counts.
+    When fewer come back than were sent, attach a `partial_failure` block (and the dropped
+    ids / client_order_ids we can identify) without hiding the orders that succeeded. No-op
+    for dry-run echoes (nothing was sent) and when every item came back.
+    """
+    if not isinstance(result, dict) or result.get("dry_run"):
+        return result
+    returned = result.get("result")
+    if not isinstance(returned, list) or len(returned) >= len(sent):
+        return result
+    returned_ids = {o.get("id") for o in returned if isinstance(o, dict)}
+    returned_coids = {o.get("client_order_id") for o in returned if isinstance(o, dict)}
+    dropped_ids = [
+        o["id"] for o in sent
+        if isinstance(o, dict) and o.get("id") is not None and o["id"] not in returned_ids
+    ]
+    dropped_coids = [
+        o["client_order_id"] for o in sent
+        if isinstance(o, dict)
+        and o.get("client_order_id") is not None
+        and o["client_order_id"] not in returned_coids
+    ]
+    partial: dict[str, Any] = {
+        "requested": len(sent),
+        "succeeded": len(returned),
+        "dropped": len(sent) - len(returned),
+    }
+    if dropped_ids:
+        partial["dropped_ids"] = dropped_ids
+    if dropped_coids:
+        partial["dropped_client_order_ids"] = dropped_coids
+    result["partial_failure"] = partial
+    return result
+
+
 def _round_to_tick(price: str, tick: Decimal) -> tuple[str, bool]:
     """Round a price string to the nearest multiple of tick.
 
@@ -336,10 +374,11 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         return await _finish("cancel_all_orders", "DELETE", "/orders/all", payload, dry_run=dry_run)
 
     # ---------------------------------------------------------------- batch orders
-    # BUG-2 (batch partial failure reported as success) is intentionally NOT handled here:
-    # Delta's batch endpoints return only the processed orders with no per-index error info,
-    # so the right contract (per-index status vs atomic reject) is an open question for the
-    # product team. Do not paper over it with a count-mismatch heuristic without that call.
+    # BUG-2: Delta's batch endpoints return only the processed orders with no per-index
+    # error info, so itemized per-index status is impossible. _flag_partial detects a
+    # count mismatch (sent N, returned M<N) and attaches a `partial_failure` block while
+    # still returning the orders that went through — the caller is told some items were
+    # dropped without losing sight of what is now live.
 
     def _check_batch(orders: list[dict[str, Any]]) -> list[dict[str, Any]]:
         if not orders:
@@ -378,7 +417,8 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
             "product_symbol": product_symbol,
             "orders": cleaned,
         }
-        return await _finish("place_batch_orders", "POST", "/orders/batch", payload, dry_run=dry_run)
+        result = await _finish("place_batch_orders", "POST", "/orders/batch", payload, dry_run=dry_run)
+        return _flag_partial(result, cleaned)
 
     @mcp.tool()
     async def edit_batch_orders(
@@ -399,7 +439,8 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
             "product_symbol": product_symbol,
             "orders": cleaned,
         }
-        return await _finish("edit_batch_orders", "PUT", "/orders/batch", payload, dry_run=dry_run)
+        result = await _finish("edit_batch_orders", "PUT", "/orders/batch", payload, dry_run=dry_run)
+        return _flag_partial(result, cleaned)
 
     @mcp.tool()
     async def cancel_batch_orders(
@@ -412,12 +453,14 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
     ) -> dict[str, Any]:
         """Cancel up to 50 orders on one contract in a single request."""
         _require_one(product_id, product_symbol)
+        cleaned = _check_batch(orders)
         payload = {
             "product_id": product_id,
             "product_symbol": product_symbol,
-            "orders": _check_batch(orders),
+            "orders": cleaned,
         }
-        return await _finish("cancel_batch_orders", "DELETE", "/orders/batch", payload, dry_run=dry_run)
+        result = await _finish("cancel_batch_orders", "DELETE", "/orders/batch", payload, dry_run=dry_run)
+        return _flag_partial(result, cleaned)
 
     # ---------------------------------------------------------------- bracket orders
 

--- a/src/delta_exchange_mcp/tools/trading.py
+++ b/src/delta_exchange_mcp/tools/trading.py
@@ -8,6 +8,8 @@ DeltaClient retry policy) — a timeout is surfaced, not silently re-sent.
 
 from __future__ import annotations
 
+import logging
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -16,6 +18,8 @@ from pydantic import Field
 from delta_exchange_mcp.audit_log import AuditLog
 from delta_exchange_mcp.client import DeltaClient
 from delta_exchange_mcp.errors import DeltaApiError
+
+logger = logging.getLogger("delta_exchange_mcp")
 
 _MAX_BATCH = 50
 _STOP_TRIGGER_METHODS = "mark_price, last_traded_price, spot_price"
@@ -44,8 +48,108 @@ def _require_one(product_id: int | None, product_symbol: str | None) -> None:
         raise ValueError("pass exactly one of product_id or product_symbol")
 
 
+def _validate_order(order_type: str | None, limit_price: str | None, size: int | None) -> None:
+    """Client-side cross-field checks the API would otherwise only catch at send time.
+
+    Runs before _finish, so dry_run surfaces the same failures as a real call. These mirror
+    documented API constraints — they are not a full server simulation.
+    """
+    if size is not None and size <= 0:
+        raise ValueError("size must be a positive integer")
+    if order_type == "limit_order" and limit_price is None:
+        raise ValueError("limit_price is required for limit_order")
+    if order_type == "market_order" and limit_price is not None:
+        raise ValueError("market_order must not carry a limit_price (it is ignored, not a cap)")
+
+
+def _round_to_tick(price: str, tick: Decimal) -> tuple[str, bool]:
+    """Round a price string to the nearest multiple of tick.
+
+    Returns (normalized_string, changed). On any parse failure the input is returned
+    unchanged so a malformed price still reaches the API for its own error.
+    """
+    try:
+        value = Decimal(price)
+    except (InvalidOperation, ValueError, TypeError):
+        return price, False
+    if tick <= 0:
+        return price, False
+    steps = (value / tick).to_integral_value(rounding="ROUND_HALF_UP")
+    snapped = (steps * tick).normalize()
+    # Render without exponent/trailing-zero noise (e.g. 62000.0 not 6.2E+4).
+    normalized = f"{snapped:f}"
+    return normalized, normalized != price
+
+
 def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -> None:
     _uid_cache: dict[str, int] = {}
+    # tick_size keyed by both product id (int) and symbol (str); filled lazily.
+    _tick_cache: dict[int | str, Decimal] = {}
+    _tick_list_loaded = {"done": False}
+
+    def _store_product(prod: dict[str, Any]) -> None:
+        tick = prod.get("tick_size")
+        if tick is None:
+            return
+        try:
+            dec = Decimal(str(tick))
+        except (InvalidOperation, ValueError):
+            return
+        if prod.get("id") is not None:
+            _tick_cache[int(prod["id"])] = dec
+        if prod.get("symbol"):
+            _tick_cache[str(prod["symbol"])] = dec
+
+    async def _tick_size(product_id: int | None, product_symbol: str | None) -> Decimal | None:
+        """Resolve a product's tick_size (cached per process). Returns None if unresolvable.
+
+        Prefers GET /products/{symbol}; for an id-only call with a cache miss it falls back
+        to the full /products list once (there is no by-id single-product endpoint) and
+        indexes every product. Never raises — price rounding must not block an order on a
+        metadata-lookup failure.
+        """
+        key: int | str | None = product_symbol if product_symbol is not None else product_id
+        if key is not None and key in _tick_cache:
+            return _tick_cache[key]
+        try:
+            if product_symbol is not None:
+                resp = await client.get(f"/products/{product_symbol}")
+                inner = resp.get("result", resp) if isinstance(resp, dict) else None
+                if isinstance(inner, dict):
+                    _store_product(inner)
+            elif not _tick_list_loaded["done"]:
+                resp = await client.get("/products")
+                products = resp.get("result", []) if isinstance(resp, dict) else []
+                for prod in products if isinstance(products, list) else []:
+                    if isinstance(prod, dict):
+                        _store_product(prod)
+                _tick_list_loaded["done"] = True
+        except Exception as e:  # noqa: BLE001 — never block an order on a lookup failure
+            logger.info("tick_size lookup failed for %s/%s: %s", product_id, product_symbol, e)
+            return None
+        return _tick_cache.get(key) if key is not None else None
+
+    async def _normalize_prices(
+        product_id: int | None, product_symbol: str | None, fields: dict[str, str | None]
+    ) -> list[dict[str, str]]:
+        """Round each non-None price in `fields` (mutated in place) to the nearest tick.
+
+        Returns a list of {field, sent, normalized} for the values that changed.
+        """
+        if not any(v is not None for v in fields.values()):
+            return []
+        tick = await _tick_size(product_id, product_symbol)
+        if tick is None:
+            return []
+        adjustments: list[dict[str, str]] = []
+        for name, raw in fields.items():
+            if raw is None:
+                continue
+            snapped, changed = _round_to_tick(raw, tick)
+            fields[name] = snapped
+            if changed:
+                adjustments.append({"field": name, "sent": raw, "normalized": snapped})
+        return adjustments
 
     async def _user_id() -> int:
         if "id" not in _uid_cache:
@@ -76,6 +180,13 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
             audit.record(tool, payload, result=result)
         return result
 
+    def _attach(result: Any, adjustments: list[dict[str, str]]) -> Any:
+        """Surface tick-rounding adjustments on the response without hiding the result."""
+        if adjustments and isinstance(result, dict):
+            key = "adjustments" if result.get("dry_run") else "price_adjustments"
+            result[key] = adjustments
+        return result
+
     # ---------------------------------------------------------------- single order
 
     @mcp.tool()
@@ -94,31 +205,60 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         post_only: bool | None = Field(default=None, description="Reject if it would take liquidity."),
         reduce_only: bool | None = Field(default=None, description="Only reduce an existing position."),
         client_order_id: str | None = Field(default=None, description="Your id, max 32 chars."),
+        bracket_stop_loss_price: str | None = Field(default=None, description="Bracket SL trigger price."),
+        bracket_stop_loss_limit_price: str | None = Field(default=None, description="Bracket SL limit price."),
+        bracket_take_profit_price: str | None = Field(default=None, description="Bracket TP trigger price."),
+        bracket_take_profit_limit_price: str | None = Field(default=None, description="Bracket TP limit price."),
+        bracket_trail_amount: str | None = Field(default=None, description="Bracket trailing-stop amount."),
+        bracket_stop_trigger_method: str | None = Field(default=None, description=_STOP_TRIGGER_METHODS),
         dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
     ) -> dict[str, Any]:
         """Place a single order. Pass exactly one of product_id or product_symbol.
 
-        limit_price is required for limit_order. For stop orders set stop_order_type plus
-        stop_price (or trail_amount).
+        limit_price is required for limit_order (and rejected on market_order). For stop
+        orders set stop_order_type plus stop_price (or trail_amount).
+
+        To attach a bracket (TP/SL) you can later edit, pass the bracket_* params here — this
+        creates an *entry-order* bracket whose id (the returned order id) is what
+        edit_bracket_order expects. (place_bracket_order instead attaches a bracket to an open
+        position; those legs are not editable via edit_bracket_order — cancel and re-place.)
+        Prices are rounded to the product's tick; see price_adjustments in the response.
         """
         _require_one(product_id, product_symbol)
+        _validate_order(order_type, limit_price, size)
+        price_fields = {
+            "limit_price": limit_price,
+            "stop_price": stop_price,
+            "bracket_stop_loss_price": bracket_stop_loss_price,
+            "bracket_stop_loss_limit_price": bracket_stop_loss_limit_price,
+            "bracket_take_profit_price": bracket_take_profit_price,
+            "bracket_take_profit_limit_price": bracket_take_profit_limit_price,
+        }
+        adjustments = await _normalize_prices(product_id, product_symbol, price_fields)
         payload = {
             "size": size,
             "side": side,
             "order_type": order_type,
             "product_id": product_id,
             "product_symbol": product_symbol,
-            "limit_price": limit_price,
+            "limit_price": price_fields["limit_price"],
             "stop_order_type": stop_order_type,
-            "stop_price": stop_price,
+            "stop_price": price_fields["stop_price"],
             "trail_amount": trail_amount,
             "stop_trigger_method": stop_trigger_method,
             "time_in_force": time_in_force,
             "post_only": _bs(post_only),
             "reduce_only": _bs(reduce_only),
             "client_order_id": client_order_id,
+            "bracket_stop_loss_price": price_fields["bracket_stop_loss_price"],
+            "bracket_stop_loss_limit_price": price_fields["bracket_stop_loss_limit_price"],
+            "bracket_take_profit_price": price_fields["bracket_take_profit_price"],
+            "bracket_take_profit_limit_price": price_fields["bracket_take_profit_limit_price"],
+            "bracket_trail_amount": bracket_trail_amount,
+            "bracket_stop_trigger_method": bracket_stop_trigger_method,
         }
-        return await _finish("place_order", "POST", "/orders", payload, dry_run=dry_run)
+        result = await _finish("place_order", "POST", "/orders", payload, dry_run=dry_run)
+        return _attach(result, adjustments)
 
     @mcp.tool()
     async def edit_order(
@@ -132,19 +272,26 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         post_only: bool | None = Field(default=None, description="Reject if it would take liquidity."),
         dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
     ) -> dict[str, Any]:
-        """Edit an open order. Pass exactly one of product_id or product_symbol."""
+        """Edit an open order. Pass exactly one of product_id or product_symbol.
+
+        Prices are rounded to the product's tick; see price_adjustments in the response.
+        """
         _require_one(product_id, product_symbol)
+        _validate_order(None, None, size)  # order_type can't change on edit; just guard size
+        price_fields = {"limit_price": limit_price, "stop_price": stop_price}
+        adjustments = await _normalize_prices(product_id, product_symbol, price_fields)
         payload = {
             "id": id,
             "size": size,
             "product_id": product_id,
             "product_symbol": product_symbol,
-            "limit_price": limit_price,
-            "stop_price": stop_price,
+            "limit_price": price_fields["limit_price"],
+            "stop_price": price_fields["stop_price"],
             "trail_amount": trail_amount,
             "post_only": _bs(post_only),
         }
-        return await _finish("edit_order", "PUT", "/orders", payload, dry_run=dry_run)
+        result = await _finish("edit_order", "PUT", "/orders", payload, dry_run=dry_run)
+        return _attach(result, adjustments)
 
     @mcp.tool()
     async def cancel_order(
@@ -170,7 +317,15 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         cancel_reduce_only_orders: bool | None = Field(default=None, description="Include reduce-only orders."),
         dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
     ) -> dict[str, Any]:
-        """Cancel open orders. WARNING: with no filters this cancels ALL of your open orders."""
+        """Cancel open orders. WARNING: with no filters this cancels ALL of your open orders.
+
+        The API's cancel_limit_orders/cancel_stop_orders/cancel_reduce_only_orders flags
+        default to false server-side, so a bare call would otherwise be a no-op. When none of
+        them is set we default all three to true so "cancel all" actually cancels everything;
+        set any flag explicitly to narrow the scope.
+        """
+        if cancel_limit_orders is None and cancel_stop_orders is None and cancel_reduce_only_orders is None:
+            cancel_limit_orders = cancel_stop_orders = cancel_reduce_only_orders = True
         payload = {
             "product_id": product_id,
             "contract_types": _csv(contract_types),
@@ -181,6 +336,10 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         return await _finish("cancel_all_orders", "DELETE", "/orders/all", payload, dry_run=dry_run)
 
     # ---------------------------------------------------------------- batch orders
+    # BUG-2 (batch partial failure reported as success) is intentionally NOT handled here:
+    # Delta's batch endpoints return only the processed orders with no per-index error info,
+    # so the right contract (per-index status vs atomic reject) is an open question for the
+    # product team. Do not paper over it with a count-mismatch heuristic without that call.
 
     def _check_batch(orders: list[dict[str, Any]]) -> list[dict[str, Any]]:
         if not orders:
@@ -199,12 +358,25 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         product_symbol: str | None = Field(default=None, description="e.g. BTCUSD (or pass product_id)."),
         dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
     ) -> dict[str, Any]:
-        """Place up to 50 orders on one contract in a single request."""
+        """Place up to 50 orders on one contract in a single request.
+
+        client_order_id must be unique within the batch (mirrors the single-order rejection);
+        cross-checking against already-open orders is not done here.
+        """
         _require_one(product_id, product_symbol)
+        cleaned = _check_batch(orders)
+        seen_coids: set[str] = set()
+        for order in cleaned:
+            _validate_order(order.get("order_type"), order.get("limit_price"), order.get("size"))
+            coid = order.get("client_order_id")
+            if coid is not None:
+                if coid in seen_coids:
+                    raise ValueError(f"duplicate client_order_id in batch: {coid}")
+                seen_coids.add(coid)
         payload = {
             "product_id": product_id,
             "product_symbol": product_symbol,
-            "orders": _check_batch(orders),
+            "orders": cleaned,
         }
         return await _finish("place_batch_orders", "POST", "/orders/batch", payload, dry_run=dry_run)
 
@@ -219,10 +391,13 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
     ) -> dict[str, Any]:
         """Edit up to 50 orders on one contract in a single request."""
         _require_one(product_id, product_symbol)
+        cleaned = _check_batch(orders)
+        for order in cleaned:
+            _validate_order(None, None, order.get("size"))  # order_type can't change on edit
         payload = {
             "product_id": product_id,
             "product_symbol": product_symbol,
-            "orders": _check_batch(orders),
+            "orders": cleaned,
         }
         return await _finish("edit_batch_orders", "PUT", "/orders/batch", payload, dry_run=dry_run)
 
@@ -259,18 +434,34 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         bracket_stop_trigger_method: str | None = Field(default=None, description=_STOP_TRIGGER_METHODS),
         dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
     ) -> dict[str, Any]:
-        """Attach a take-profit / stop-loss bracket to a position. Provide at least one leg."""
+        """Attach a take-profit / stop-loss bracket to a position. Provide at least one leg.
+
+        Note: these legs are not editable via edit_bracket_order (cancel + re-place to change
+        them). Prices are rounded to the product's tick; see price_adjustments in the response.
+        """
         _require_one(product_id, product_symbol)
         if stop_loss_order is None and take_profit_order is None:
             raise ValueError("provide at least one of stop_loss_order or take_profit_order")
+        sl = _clean(stop_loss_order) if stop_loss_order else None
+        tp = _clean(take_profit_order) if take_profit_order else None
+        adjustments: list[dict[str, str]] = []
+        for leg_name, leg in (("stop_loss_order", sl), ("take_profit_order", tp)):
+            if not leg:
+                continue
+            leg_fields = {k: leg.get(k) for k in ("stop_price", "limit_price")}
+            for adj in await _normalize_prices(product_id, product_symbol, leg_fields):
+                adj["field"] = f"{leg_name}.{adj['field']}"
+                adjustments.append(adj)
+            leg.update({k: v for k, v in leg_fields.items() if v is not None})
         payload = {
             "product_id": product_id,
             "product_symbol": product_symbol,
-            "stop_loss_order": _clean(stop_loss_order) if stop_loss_order else None,
-            "take_profit_order": _clean(take_profit_order) if take_profit_order else None,
+            "stop_loss_order": sl,
+            "take_profit_order": tp,
             "bracket_stop_trigger_method": bracket_stop_trigger_method,
         }
-        return await _finish("place_bracket_order", "POST", "/orders/bracket", payload, dry_run=dry_run)
+        result = await _finish("place_bracket_order", "POST", "/orders/bracket", payload, dry_run=dry_run)
+        return _attach(result, adjustments)
 
     @mcp.tool()
     async def edit_bracket_order(
@@ -285,20 +476,34 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         bracket_stop_trigger_method: str | None = Field(default=None, description=_STOP_TRIGGER_METHODS),
         dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
     ) -> dict[str, Any]:
-        """Edit the bracket (TP/SL) params on an existing order."""
+        """Edit the bracket (TP/SL) params on an existing order.
+
+        `id` is the *entry order* id (an order created with bracket_* params, e.g. via
+        place_order(..., bracket_take_profit_price=...)). It does NOT accept the leg ids of a
+        position bracket created by place_bracket_order. Prices are rounded to the product's
+        tick; see price_adjustments in the response.
+        """
         _require_one(product_id, product_symbol)
-        payload = {
-            "id": id,
-            "product_id": product_id,
-            "product_symbol": product_symbol,
+        price_fields = {
             "bracket_stop_loss_price": bracket_stop_loss_price,
             "bracket_stop_loss_limit_price": bracket_stop_loss_limit_price,
             "bracket_take_profit_price": bracket_take_profit_price,
             "bracket_take_profit_limit_price": bracket_take_profit_limit_price,
+        }
+        adjustments = await _normalize_prices(product_id, product_symbol, price_fields)
+        payload = {
+            "id": id,
+            "product_id": product_id,
+            "product_symbol": product_symbol,
+            "bracket_stop_loss_price": price_fields["bracket_stop_loss_price"],
+            "bracket_stop_loss_limit_price": price_fields["bracket_stop_loss_limit_price"],
+            "bracket_take_profit_price": price_fields["bracket_take_profit_price"],
+            "bracket_take_profit_limit_price": price_fields["bracket_take_profit_limit_price"],
             "bracket_trail_amount": bracket_trail_amount,
             "bracket_stop_trigger_method": bracket_stop_trigger_method,
         }
-        return await _finish("edit_bracket_order", "PUT", "/orders/bracket", payload, dry_run=dry_run)
+        result = await _finish("edit_bracket_order", "PUT", "/orders/bracket", payload, dry_run=dry_run)
+        return _attach(result, adjustments)
 
     # ---------------------------------------------------------------- positions & leverage
 
@@ -328,15 +533,18 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
 
     @mcp.tool()
     async def close_all_positions(
-        close_all_portfolio: bool = Field(default=True, description="Close cross/portfolio-margined positions."),
-        close_all_isolated: bool = Field(default=True, description="Close isolated-margin positions."),
+        close_all_portfolio: bool = Field(default=False, description="Close cross/portfolio-margined positions."),
+        close_all_isolated: bool = Field(default=False, description="Close isolated-margin positions."),
         dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
     ) -> dict[str, Any]:
-        """Close all open positions. WARNING: closes everything matching the flags.
+        """Close open positions in the scopes you set to true. Both flags default to false,
+        so you must explicitly opt into a scope — this never broadens beyond your request.
 
         Your user_id is required by the API and is resolved automatically from your profile
         (fetched once and cached) — you do not pass it.
         """
+        if not (close_all_portfolio or close_all_isolated):
+            raise ValueError("set at least one of close_all_portfolio or close_all_isolated to true")
         payload = {
             "close_all_portfolio": close_all_portfolio,
             "close_all_isolated": close_all_isolated,

--- a/src/delta_exchange_mcp/tools/trading.py
+++ b/src/delta_exchange_mcp/tools/trading.py
@@ -1,0 +1,355 @@
+"""Authenticated trading tools (mutations).
+
+Registered only when DELTA_API_KEY/SECRET are set AND DELTA_MCP_MODE=trade. Every tool
+takes a `dry_run` flag that validates and echoes the payload without sending it, and every
+call (dry-run or real) is recorded to the audit log. Mutations never auto-retry (see
+DeltaClient retry policy) — a timeout is surfaced, not silently re-sent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+from pydantic import Field
+
+from delta_exchange_mcp.audit_log import AuditLog
+from delta_exchange_mcp.client import DeltaClient
+from delta_exchange_mcp.errors import DeltaApiError
+
+_MAX_BATCH = 50
+_STOP_TRIGGER_METHODS = "mark_price, last_traded_price, spot_price"
+
+
+def _bs(value: bool | None) -> str | None:
+    """Delta's order-level flags are string enums "true"/"false", not JSON booleans."""
+    if value is None:
+        return None
+    return "true" if value else "false"
+
+
+def _csv(values: list[str] | None) -> str | None:
+    if not values:
+        return None
+    return ",".join(values)
+
+
+def _clean(payload: dict[str, Any]) -> dict[str, Any]:
+    """Drop None-valued keys so we never send `field: null` in a request body."""
+    return {k: v for k, v in payload.items() if v is not None}
+
+
+def _require_one(product_id: int | None, product_symbol: str | None) -> None:
+    if (product_id is None) == (product_symbol is None):
+        raise ValueError("pass exactly one of product_id or product_symbol")
+
+
+def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -> None:
+    _uid_cache: dict[str, int] = {}
+
+    async def _user_id() -> int:
+        if "id" not in _uid_cache:
+            prof = await client.get("/profile", auth=True)
+            inner = prof.get("result", prof) if isinstance(prof, dict) else {}
+            uid = inner.get("id") or inner.get("user_id") if isinstance(inner, dict) else None
+            if uid is None:
+                raise ValueError("could not resolve user_id from /profile")
+            _uid_cache["id"] = int(uid)
+        return _uid_cache["id"]
+
+    async def _finish(
+        tool: str, method: str, path: str, payload: dict[str, Any], *, dry_run: bool
+    ) -> Any:
+        payload = _clean(payload)
+        if dry_run:
+            if audit:
+                audit.record(tool, payload, dry_run=True)
+            return {"dry_run": True, "method": method, "path": path, "payload": payload}
+        sender = {"POST": client.post, "PUT": client.put, "DELETE": client.delete}[method]
+        try:
+            result = await sender(path, payload, auth=True)
+        except DeltaApiError as e:
+            if audit:
+                audit.record(tool, payload, error=str(e))
+            raise
+        if audit:
+            audit.record(tool, payload, result=result)
+        return result
+
+    # ---------------------------------------------------------------- single order
+
+    @mcp.tool()
+    async def place_order(
+        size: int = Field(description="Order size in contracts."),
+        side: str = Field(description="buy or sell."),
+        order_type: str = Field(description="limit_order or market_order."),
+        product_id: int | None = Field(default=None, description="Product id (or pass product_symbol)."),
+        product_symbol: str | None = Field(default=None, description="e.g. BTCUSD (or pass product_id)."),
+        limit_price: str | None = Field(default=None, description="Required for limit_order."),
+        stop_order_type: str | None = Field(default=None, description="stop_loss_order or take_profit_order."),
+        stop_price: str | None = Field(default=None, description="Trigger price for stop orders."),
+        trail_amount: str | None = Field(default=None, description="Trailing-stop amount."),
+        stop_trigger_method: str | None = Field(default=None, description=_STOP_TRIGGER_METHODS),
+        time_in_force: str | None = Field(default=None, description="gtc or ioc."),
+        post_only: bool | None = Field(default=None, description="Reject if it would take liquidity."),
+        reduce_only: bool | None = Field(default=None, description="Only reduce an existing position."),
+        client_order_id: str | None = Field(default=None, description="Your id, max 32 chars."),
+        dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
+    ) -> dict[str, Any]:
+        """Place a single order. Pass exactly one of product_id or product_symbol.
+
+        limit_price is required for limit_order. For stop orders set stop_order_type plus
+        stop_price (or trail_amount).
+        """
+        _require_one(product_id, product_symbol)
+        payload = {
+            "size": size,
+            "side": side,
+            "order_type": order_type,
+            "product_id": product_id,
+            "product_symbol": product_symbol,
+            "limit_price": limit_price,
+            "stop_order_type": stop_order_type,
+            "stop_price": stop_price,
+            "trail_amount": trail_amount,
+            "stop_trigger_method": stop_trigger_method,
+            "time_in_force": time_in_force,
+            "post_only": _bs(post_only),
+            "reduce_only": _bs(reduce_only),
+            "client_order_id": client_order_id,
+        }
+        return await _finish("place_order", "POST", "/orders", payload, dry_run=dry_run)
+
+    @mcp.tool()
+    async def edit_order(
+        id: int = Field(description="Order id to edit."),
+        size: int = Field(description="Total size after the edit."),
+        product_id: int | None = Field(default=None, description="Product id (or pass product_symbol)."),
+        product_symbol: str | None = Field(default=None, description="e.g. BTCUSD (or pass product_id)."),
+        limit_price: str | None = Field(default=None, description="New limit price."),
+        stop_price: str | None = Field(default=None, description="New stop trigger price."),
+        trail_amount: str | None = Field(default=None, description="New trailing-stop amount."),
+        post_only: bool | None = Field(default=None, description="Reject if it would take liquidity."),
+        dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
+    ) -> dict[str, Any]:
+        """Edit an open order. Pass exactly one of product_id or product_symbol."""
+        _require_one(product_id, product_symbol)
+        payload = {
+            "id": id,
+            "size": size,
+            "product_id": product_id,
+            "product_symbol": product_symbol,
+            "limit_price": limit_price,
+            "stop_price": stop_price,
+            "trail_amount": trail_amount,
+            "post_only": _bs(post_only),
+        }
+        return await _finish("edit_order", "PUT", "/orders", payload, dry_run=dry_run)
+
+    @mcp.tool()
+    async def cancel_order(
+        product_id: int = Field(description="Product id the order belongs to."),
+        id: int | None = Field(default=None, description="Order id to cancel."),
+        client_order_id: str | None = Field(default=None, description="Your client_order_id."),
+        dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
+    ) -> dict[str, Any]:
+        """Cancel a single order by id or client_order_id."""
+        if (id is None) == (client_order_id is None):
+            raise ValueError("pass exactly one of id or client_order_id")
+        payload = {"product_id": product_id, "id": id, "client_order_id": client_order_id}
+        return await _finish("cancel_order", "DELETE", "/orders", payload, dry_run=dry_run)
+
+    @mcp.tool()
+    async def cancel_all_orders(
+        product_id: int | None = Field(default=None, description="Limit to one product."),
+        contract_types: list[str] | None = Field(
+            default=None, description="Limit to contract types (ignored if product_id is set)."
+        ),
+        cancel_limit_orders: bool | None = Field(default=None, description="Include limit orders."),
+        cancel_stop_orders: bool | None = Field(default=None, description="Include stop orders."),
+        cancel_reduce_only_orders: bool | None = Field(default=None, description="Include reduce-only orders."),
+        dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
+    ) -> dict[str, Any]:
+        """Cancel open orders. WARNING: with no filters this cancels ALL of your open orders."""
+        payload = {
+            "product_id": product_id,
+            "contract_types": _csv(contract_types),
+            "cancel_limit_orders": _bs(cancel_limit_orders),
+            "cancel_stop_orders": _bs(cancel_stop_orders),
+            "cancel_reduce_only_orders": _bs(cancel_reduce_only_orders),
+        }
+        return await _finish("cancel_all_orders", "DELETE", "/orders/all", payload, dry_run=dry_run)
+
+    # ---------------------------------------------------------------- batch orders
+
+    def _check_batch(orders: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if not orders:
+            raise ValueError("orders must be a non-empty list")
+        if len(orders) > _MAX_BATCH:
+            raise ValueError(f"batch size {len(orders)} exceeds max {_MAX_BATCH}")
+        return [_clean(o) for o in orders]
+
+    @mcp.tool()
+    async def place_batch_orders(
+        orders: list[dict[str, Any]] = Field(
+            description="Up to 50 orders, each {size, side, order_type, limit_price?, "
+            "time_in_force?, post_only?, client_order_id?}. All same contract. No IOC/stop."
+        ),
+        product_id: int | None = Field(default=None, description="Product id (or pass product_symbol)."),
+        product_symbol: str | None = Field(default=None, description="e.g. BTCUSD (or pass product_id)."),
+        dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
+    ) -> dict[str, Any]:
+        """Place up to 50 orders on one contract in a single request."""
+        _require_one(product_id, product_symbol)
+        payload = {
+            "product_id": product_id,
+            "product_symbol": product_symbol,
+            "orders": _check_batch(orders),
+        }
+        return await _finish("place_batch_orders", "POST", "/orders/batch", payload, dry_run=dry_run)
+
+    @mcp.tool()
+    async def edit_batch_orders(
+        orders: list[dict[str, Any]] = Field(
+            description="Up to 50 edits, each {id, size, order_type, limit_price?, post_only?}."
+        ),
+        product_id: int | None = Field(default=None, description="Product id (or pass product_symbol)."),
+        product_symbol: str | None = Field(default=None, description="e.g. BTCUSD (or pass product_id)."),
+        dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
+    ) -> dict[str, Any]:
+        """Edit up to 50 orders on one contract in a single request."""
+        _require_one(product_id, product_symbol)
+        payload = {
+            "product_id": product_id,
+            "product_symbol": product_symbol,
+            "orders": _check_batch(orders),
+        }
+        return await _finish("edit_batch_orders", "PUT", "/orders/batch", payload, dry_run=dry_run)
+
+    @mcp.tool()
+    async def cancel_batch_orders(
+        orders: list[dict[str, Any]] = Field(
+            description="Up to 50 orders to cancel, each {id} or {client_order_id}."
+        ),
+        product_id: int | None = Field(default=None, description="Product id (or pass product_symbol)."),
+        product_symbol: str | None = Field(default=None, description="e.g. BTCUSD (or pass product_id)."),
+        dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
+    ) -> dict[str, Any]:
+        """Cancel up to 50 orders on one contract in a single request."""
+        _require_one(product_id, product_symbol)
+        payload = {
+            "product_id": product_id,
+            "product_symbol": product_symbol,
+            "orders": _check_batch(orders),
+        }
+        return await _finish("cancel_batch_orders", "DELETE", "/orders/batch", payload, dry_run=dry_run)
+
+    # ---------------------------------------------------------------- bracket orders
+
+    @mcp.tool()
+    async def place_bracket_order(
+        product_id: int | None = Field(default=None, description="Product id (or pass product_symbol)."),
+        product_symbol: str | None = Field(default=None, description="e.g. BTCUSD (or pass product_id)."),
+        stop_loss_order: dict[str, Any] | None = Field(
+            default=None, description="{order_type, stop_price, limit_price?, trail_amount?}."
+        ),
+        take_profit_order: dict[str, Any] | None = Field(
+            default=None, description="{order_type, stop_price, limit_price?}."
+        ),
+        bracket_stop_trigger_method: str | None = Field(default=None, description=_STOP_TRIGGER_METHODS),
+        dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
+    ) -> dict[str, Any]:
+        """Attach a take-profit / stop-loss bracket to a position. Provide at least one leg."""
+        _require_one(product_id, product_symbol)
+        if stop_loss_order is None and take_profit_order is None:
+            raise ValueError("provide at least one of stop_loss_order or take_profit_order")
+        payload = {
+            "product_id": product_id,
+            "product_symbol": product_symbol,
+            "stop_loss_order": _clean(stop_loss_order) if stop_loss_order else None,
+            "take_profit_order": _clean(take_profit_order) if take_profit_order else None,
+            "bracket_stop_trigger_method": bracket_stop_trigger_method,
+        }
+        return await _finish("place_bracket_order", "POST", "/orders/bracket", payload, dry_run=dry_run)
+
+    @mcp.tool()
+    async def edit_bracket_order(
+        id: int = Field(description="Order id whose bracket params to update."),
+        product_id: int | None = Field(default=None, description="Product id (or pass product_symbol)."),
+        product_symbol: str | None = Field(default=None, description="e.g. BTCUSD (or pass product_id)."),
+        bracket_stop_loss_price: str | None = Field(default=None, description="Stop-loss trigger price."),
+        bracket_stop_loss_limit_price: str | None = Field(default=None, description="Stop-loss limit price."),
+        bracket_take_profit_price: str | None = Field(default=None, description="Take-profit trigger price."),
+        bracket_take_profit_limit_price: str | None = Field(default=None, description="Take-profit limit price."),
+        bracket_trail_amount: str | None = Field(default=None, description="Trailing-stop amount."),
+        bracket_stop_trigger_method: str | None = Field(default=None, description=_STOP_TRIGGER_METHODS),
+        dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
+    ) -> dict[str, Any]:
+        """Edit the bracket (TP/SL) params on an existing order."""
+        _require_one(product_id, product_symbol)
+        payload = {
+            "id": id,
+            "product_id": product_id,
+            "product_symbol": product_symbol,
+            "bracket_stop_loss_price": bracket_stop_loss_price,
+            "bracket_stop_loss_limit_price": bracket_stop_loss_limit_price,
+            "bracket_take_profit_price": bracket_take_profit_price,
+            "bracket_take_profit_limit_price": bracket_take_profit_limit_price,
+            "bracket_trail_amount": bracket_trail_amount,
+            "bracket_stop_trigger_method": bracket_stop_trigger_method,
+        }
+        return await _finish("edit_bracket_order", "PUT", "/orders/bracket", payload, dry_run=dry_run)
+
+    # ---------------------------------------------------------------- positions & leverage
+
+    @mcp.tool()
+    async def set_product_leverage(
+        product_id: int = Field(description="Product id to set order leverage for."),
+        leverage: str = Field(description="Leverage multiplier, e.g. '10'."),
+        dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
+    ) -> dict[str, Any]:
+        """Set order leverage for a product."""
+        return await _finish(
+            "set_product_leverage", "POST",
+            f"/products/{product_id}/orders/leverage", {"leverage": leverage}, dry_run=dry_run,
+        )
+
+    @mcp.tool()
+    async def adjust_position_margin(
+        product_id: int = Field(description="Product id of the position."),
+        delta_margin: str = Field(description="Margin to add (positive) or remove (negative), e.g. '5.0'."),
+        dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
+    ) -> dict[str, Any]:
+        """Add or remove isolated margin on a position."""
+        payload = {"product_id": product_id, "delta_margin": delta_margin}
+        return await _finish(
+            "adjust_position_margin", "POST", "/positions/change_margin", payload, dry_run=dry_run
+        )
+
+    @mcp.tool()
+    async def close_all_positions(
+        close_all_portfolio: bool = Field(default=True, description="Close cross/portfolio-margined positions."),
+        close_all_isolated: bool = Field(default=True, description="Close isolated-margin positions."),
+        dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
+    ) -> dict[str, Any]:
+        """Close all open positions. WARNING: closes everything matching the flags.
+
+        Your user_id is required by the API and is resolved automatically from your profile
+        (fetched once and cached) — you do not pass it.
+        """
+        payload = {
+            "close_all_portfolio": close_all_portfolio,
+            "close_all_isolated": close_all_isolated,
+            "user_id": await _user_id(),
+        }
+        return await _finish("close_all_positions", "POST", "/positions/close_all", payload, dry_run=dry_run)
+
+    @mcp.tool()
+    async def configure_auto_topup(
+        product_id: int = Field(description="Product id of the position."),
+        auto_topup: bool = Field(description="Enable or disable auto top-up for this position."),
+        dry_run: bool = Field(default=False, description="Validate + echo payload without sending."),
+    ) -> dict[str, Any]:
+        """Override auto top-up for a single position (otherwise inherits the account setting)."""
+        payload = {"product_id": product_id, "auto_topup": auto_topup}
+        return await _finish("configure_auto_topup", "PUT", "/positions/auto_topup", payload, dry_run=dry_run)

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -285,6 +285,63 @@ async def test_batch_rejects_duplicate_client_order_id():
     assert route.called is False
 
 
+# --------------------------------------------------------------- BUG-2: batch partial failure
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_place_batch_flags_partial_failure_with_dropped_coids():
+    # sent 3, API echoes only 2 — the size:0 item is dropped silently by Delta.
+    route = respx.post(f"{INDIA_TESTNET_REST}/orders/batch").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": [
+            {"id": 1, "client_order_id": "a"},
+            {"id": 2, "client_order_id": "c"},
+        ]})
+    )
+    client = _client()
+    orders = [
+        {"side": "buy", "order_type": "limit_order", "limit_price": "61000", "size": 1, "client_order_id": "a"},
+        {"side": "buy", "order_type": "limit_order", "limit_price": "61000", "size": 1, "client_order_id": "b"},
+        {"side": "buy", "order_type": "limit_order", "limit_price": "61000", "size": 1, "client_order_id": "c"},
+    ]
+    out = await _call(client, "place_batch_orders", product_id=84, orders=orders)
+    assert route.called
+    pf = out[1]["partial_failure"]
+    assert pf["requested"] == 3 and pf["succeeded"] == 2 and pf["dropped"] == 1
+    assert pf["dropped_client_order_ids"] == ["b"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_cancel_batch_flags_dropped_ids():
+    respx.delete(f"{INDIA_TESTNET_REST}/orders/batch").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": [{"id": 111}]})
+    )
+    client = _client()
+    out = await _call(
+        client, "cancel_batch_orders", product_id=84,
+        orders=[{"id": 111}, {"id": 999999999}],
+    )
+    pf = out[1]["partial_failure"]
+    assert pf["requested"] == 2 and pf["succeeded"] == 1
+    assert pf["dropped_ids"] == [999999999]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_batch_no_partial_flag_when_all_succeed():
+    respx.post(f"{INDIA_TESTNET_REST}/orders/batch").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": [{"id": 1}, {"id": 2}]})
+    )
+    client = _client()
+    orders = [
+        {"side": "buy", "order_type": "limit_order", "limit_price": "61000", "size": 1},
+        {"side": "buy", "order_type": "limit_order", "limit_price": "61000", "size": 1},
+    ]
+    out = await _call(client, "place_batch_orders", product_id=84, orders=orders)
+    assert "partial_failure" not in out[1]
+
+
 # --------------------------------------------------------------- BUG-4: close_all scope
 
 

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -1,0 +1,234 @@
+"""Trading tools: body signing, dry-run, validation, user_id caching, audit, mode gating."""
+
+import hashlib
+import hmac
+import json
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from delta_exchange_mcp import audit_log
+from delta_exchange_mcp.client import DeltaClient
+from delta_exchange_mcp.config import INDIA_TESTNET_REST, Config
+from delta_exchange_mcp.server import build_server
+from delta_exchange_mcp.tools import trading
+from mcp.server.fastmcp import FastMCP
+
+
+def _client() -> DeltaClient:
+    cfg = Config(
+        env="india_testnet", base_url=INDIA_TESTNET_REST,
+        api_key="k1", api_secret="s1", mode="trade",
+    )
+    return DeltaClient(cfg)
+
+
+async def _call(client: DeltaClient, name: str, audit=None, **kwargs: Any) -> Any:
+    mcp = FastMCP("test")
+    trading.register(mcp, client, audit)
+    return await mcp.call_tool(name, kwargs)
+
+
+def _payload(call_result: Any) -> dict[str, Any]:
+    """mcp.call_tool returns (content, structured); pull the structured dict out."""
+    structured = call_result[1]
+    return structured.get("result", structured) if isinstance(structured, dict) else structured
+
+
+# --------------------------------------------------------------- body signing (critical)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_place_order_signs_exact_body_bytes():
+    route = respx.post(f"{INDIA_TESTNET_REST}/orders").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": {"id": 7}})
+    )
+    client = _client()
+    await _call(
+        client, "place_order",
+        product_id=27, size=1, side="buy", order_type="limit_order", limit_price="10000",
+    )
+
+    req = route.calls[0].request
+    body = req.content.decode()
+    # Sent bytes must be compact JSON (no spaces) so the signature matches.
+    assert body == json.dumps(json.loads(body), separators=(",", ":"))
+    ts = req.headers["timestamp"]
+    expected = hmac.new(b"s1", f"POST{ts}/v2/orders{body}".encode(), hashlib.sha256).hexdigest()
+    assert req.headers["signature"] == expected
+    assert req.headers["api-key"] == "k1"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_post_only_bool_becomes_string_enum():
+    route = respx.post(f"{INDIA_TESTNET_REST}/orders").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": {}})
+    )
+    client = _client()
+    await _call(
+        client, "place_order",
+        product_id=27, size=1, side="buy", order_type="market_order", post_only=True,
+    )
+    assert route.calls[0].request.read().__contains__(b'"post_only":"true"')
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_auto_topup_bool_stays_json_bool():
+    route = respx.put(f"{INDIA_TESTNET_REST}/positions/auto_topup").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": {}})
+    )
+    client = _client()
+    await _call(client, "configure_auto_topup", product_id=27, auto_topup=True)
+    assert b'"auto_topup":true' in route.calls[0].request.content
+
+
+# --------------------------------------------------------------- dry-run
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_dry_run_sends_nothing_and_echoes_payload():
+    route = respx.post(f"{INDIA_TESTNET_REST}/orders").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": {}})
+    )
+    client = _client()
+    out = _payload(await _call(
+        client, "place_order",
+        product_id=27, size=2, side="sell", order_type="market_order", dry_run=True,
+    ))
+    assert route.called is False
+    assert out["dry_run"] is True
+    assert out["method"] == "POST" and out["path"] == "/orders"
+    assert out["payload"]["size"] == 2 and out["payload"]["side"] == "sell"
+
+
+# --------------------------------------------------------------- validation
+
+
+@pytest.mark.asyncio
+async def test_place_order_requires_exactly_one_product_ref():
+    client = _client()
+    with pytest.raises(Exception, match="exactly one of product_id or product_symbol"):
+        await _call(client, "place_order", size=1, side="buy", order_type="market_order")
+    with pytest.raises(Exception, match="exactly one of product_id or product_symbol"):
+        await _call(
+            client, "place_order",
+            product_id=1, product_symbol="BTCUSD", size=1, side="buy", order_type="market_order",
+        )
+
+
+@pytest.mark.asyncio
+async def test_batch_cap_enforced():
+    client = _client()
+    orders = [{"size": 1, "side": "buy", "order_type": "limit_order", "limit_price": "1"}] * 51
+    with pytest.raises(Exception, match="exceeds max 50"):
+        await _call(client, "place_batch_orders", product_id=27, orders=orders)
+
+
+# --------------------------------------------------------------- user_id auto-fetch
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_close_all_fetches_and_caches_user_id():
+    profile = respx.get(f"{INDIA_TESTNET_REST}/profile").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": {"id": 999}})
+    )
+    close = respx.post(f"{INDIA_TESTNET_REST}/positions/close_all").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": {}})
+    )
+    client = _client()
+    mcp = FastMCP("test")
+    trading.register(mcp, client, None)
+    await mcp.call_tool("close_all_positions", {})
+    await mcp.call_tool("close_all_positions", {})
+
+    assert profile.call_count == 1  # cached after first fetch
+    assert close.call_count == 2
+    assert b'"user_id":999' in close.calls[0].request.content
+
+
+# --------------------------------------------------------------- audit log
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_audit_records_success_and_error_without_secrets(tmp_path, monkeypatch):
+    monkeypatch.setenv("DELTA_MCP_AUDIT_FILE", str(tmp_path / "audit.log"))
+    monkeypatch.setattr(audit_log, "_INSTANCE", None)
+    cfg = Config(
+        env="india_testnet", base_url=INDIA_TESTNET_REST,
+        api_key="k1", api_secret="s1", mode="trade",
+    )
+    audit = audit_log.configure(cfg)
+    assert audit is not None
+
+    respx.post(f"{INDIA_TESTNET_REST}/orders").mock(
+        side_effect=[
+            httpx.Response(200, json={"success": True, "result": {"id": 5, "state": "open"}}),
+            httpx.Response(400, json={"success": False, "error": {"code": "insufficient_margin"}}),
+        ]
+    )
+    client = _client()
+    await _call(client, "place_order", audit=audit,
+                product_id=27, size=1, side="buy", order_type="market_order")
+    # FastMCP wraps the DeltaApiError in a ToolError, but _finish records it first.
+    with pytest.raises(Exception, match="insufficient_margin"):
+        await _call(client, "place_order", audit=audit,
+                    product_id=27, size=1, side="buy", order_type="market_order")
+
+    text = (tmp_path / "audit.log").read_text()
+    lines = [json.loads(line) for line in text.splitlines()]
+    assert len(lines) == 2
+    assert lines[0]["result"] == {"id": 5, "state": "open"}
+    assert "insufficient_margin" in lines[1]["error"]
+    # Credentials must never appear in the audit file.
+    assert "s1" not in text and "signature" not in text and "api-key" not in text
+
+
+@pytest.mark.asyncio
+async def test_audit_kill_switch(tmp_path, monkeypatch):
+    monkeypatch.setenv("DELTA_MCP_AUDIT", "off")
+    monkeypatch.setattr(audit_log, "_INSTANCE", None)
+    cfg = Config(
+        env="india_testnet", base_url=INDIA_TESTNET_REST,
+        api_key="k1", api_secret="s1", mode="trade",
+    )
+    assert audit_log.configure(cfg) is None
+
+
+# --------------------------------------------------------------- mode gating
+
+
+def test_trade_tools_absent_in_read_mode():
+    cfg = Config(
+        env="india_testnet", base_url=INDIA_TESTNET_REST,
+        api_key="k1", api_secret="s1", mode="read",
+    )
+    mcp = build_server(cfg)
+    names = {t.name for t in mcp._tool_manager.list_tools()}
+    assert "place_order" not in names
+    assert "get_positions" in names  # account tools still present
+
+
+def test_trade_tools_present_in_trade_mode(monkeypatch):
+    monkeypatch.setenv("DELTA_MCP_AUDIT", "off")  # no file writes during this test
+    monkeypatch.setattr(audit_log, "_INSTANCE", None)
+    cfg = Config(
+        env="india_testnet", base_url=INDIA_TESTNET_REST,
+        api_key="k1", api_secret="s1", mode="trade",
+    )
+    mcp = build_server(cfg)
+    names = {t.name for t in mcp._tool_manager.list_tools()}
+    for tool in (
+        "place_order", "edit_order", "cancel_order", "cancel_all_orders",
+        "place_batch_orders", "edit_batch_orders", "cancel_batch_orders",
+        "place_bracket_order", "edit_bracket_order", "set_product_leverage",
+        "adjust_position_margin", "close_all_positions", "configure_auto_topup",
+    ):
+        assert tool in names

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -145,8 +145,8 @@ async def test_close_all_fetches_and_caches_user_id():
     client = _client()
     mcp = FastMCP("test")
     trading.register(mcp, client, None)
-    await mcp.call_tool("close_all_positions", {})
-    await mcp.call_tool("close_all_positions", {})
+    await mcp.call_tool("close_all_positions", {"close_all_portfolio": True})
+    await mcp.call_tool("close_all_positions", {"close_all_portfolio": True})
 
     assert profile.call_count == 1  # cached after first fetch
     assert close.call_count == 2
@@ -232,3 +232,186 @@ def test_trade_tools_present_in_trade_mode(monkeypatch):
         "adjust_position_margin", "close_all_positions", "configure_auto_topup",
     ):
         assert tool in names
+
+
+# --------------------------------------------------------------- BUG-1: cancel_all defaults
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_cancel_all_bare_call_defaults_all_flags_true():
+    route = respx.delete(f"{INDIA_TESTNET_REST}/orders/all").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": {}})
+    )
+    client = _client()
+    await _call(client, "cancel_all_orders", product_id=84)
+    body = route.calls[0].request.content
+    assert b'"cancel_limit_orders":"true"' in body
+    assert b'"cancel_stop_orders":"true"' in body
+    assert b'"cancel_reduce_only_orders":"true"' in body
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_cancel_all_explicit_flag_stays_narrow():
+    route = respx.delete(f"{INDIA_TESTNET_REST}/orders/all").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": {}})
+    )
+    client = _client()
+    await _call(client, "cancel_all_orders", product_id=84, cancel_limit_orders=True)
+    body = route.calls[0].request.content
+    assert b'"cancel_limit_orders":"true"' in body
+    # the other two are NOT auto-set when one flag is given explicitly
+    assert b"cancel_stop_orders" not in body
+    assert b"cancel_reduce_only_orders" not in body
+
+
+# --------------------------------------------------------------- BUG-3: duplicate coid in batch
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_batch_rejects_duplicate_client_order_id():
+    route = respx.post(f"{INDIA_TESTNET_REST}/orders/batch").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": []})
+    )
+    client = _client()
+    orders = [
+        {"side": "buy", "order_type": "limit_order", "limit_price": "61000", "size": 1, "client_order_id": "dup"},
+        {"side": "buy", "order_type": "limit_order", "limit_price": "61001", "size": 1, "client_order_id": "dup"},
+    ]
+    with pytest.raises(Exception, match="duplicate client_order_id in batch: dup"):
+        await _call(client, "place_batch_orders", product_id=84, orders=orders)
+    assert route.called is False
+
+
+# --------------------------------------------------------------- BUG-4: close_all scope
+
+
+@pytest.mark.asyncio
+async def test_close_all_requires_a_scope():
+    client = _client()
+    with pytest.raises(Exception, match="at least one of close_all_portfolio or close_all_isolated"):
+        await _call(client, "close_all_positions")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_close_all_explicit_scope_not_broadened():
+    respx.get(f"{INDIA_TESTNET_REST}/profile").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": {"id": 7}})
+    )
+    route = respx.post(f"{INDIA_TESTNET_REST}/positions/close_all").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": {}})
+    )
+    client = _client()
+    await _call(client, "close_all_positions", close_all_isolated=True)
+    body = route.calls[0].request.content
+    assert b'"close_all_isolated":true' in body
+    assert b'"close_all_portfolio":false' in body
+
+
+# --------------------------------------------------------------- BUG-5: place_order brackets
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_place_order_includes_bracket_params():
+    route = respx.post(f"{INDIA_TESTNET_REST}/orders").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": {"id": 9}})
+    )
+    client = _client()
+    await _call(
+        client, "place_order",
+        product_id=84, size=1, side="buy", order_type="limit_order", limit_price="61000",
+        bracket_take_profit_price="66500", bracket_stop_loss_price="60000",
+    )
+    body = route.calls[0].request.content
+    assert b'"bracket_take_profit_price":"66500"' in body
+    assert b'"bracket_stop_loss_price":"60000"' in body
+
+
+# --------------------------------------------------------------- BUG-6/7: order validation
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_market_order_rejects_limit_price():
+    route = respx.post(f"{INDIA_TESTNET_REST}/orders").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": {}})
+    )
+    client = _client()
+    for dry in (False, True):
+        with pytest.raises(Exception, match="market_order must not carry a limit_price"):
+            await _call(
+                client, "place_order",
+                product_id=84, size=1, side="buy", order_type="market_order",
+                limit_price="50000", dry_run=dry,
+            )
+    assert route.called is False
+
+
+@pytest.mark.asyncio
+async def test_limit_order_requires_limit_price():
+    client = _client()
+    with pytest.raises(Exception, match="limit_price is required for limit_order"):
+        await _call(
+            client, "place_order",
+            product_id=84, size=1, side="buy", order_type="limit_order", dry_run=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_positive_size_rejected():
+    client = _client()
+    with pytest.raises(Exception, match="size must be a positive integer"):
+        await _call(
+            client, "place_order",
+            product_id=84, size=-5, side="buy", order_type="limit_order",
+            limit_price="61000", dry_run=True,
+        )
+
+
+# --------------------------------------------------------------- BUG-8: tick rounding
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_off_tick_price_rounded_to_nearest():
+    respx.get(f"{INDIA_TESTNET_REST}/products/BTCUSD").mock(
+        return_value=httpx.Response(
+            200, json={"success": True, "result": {"id": 84, "symbol": "BTCUSD", "tick_size": "0.1"}}
+        )
+    )
+    route = respx.post(f"{INDIA_TESTNET_REST}/orders").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": {"id": 1}})
+    )
+    client = _client()
+    out = await _call(
+        client, "place_order",
+        product_symbol="BTCUSD", size=1, side="buy", order_type="limit_order", limit_price="62000.07",
+    )
+    assert b'"limit_price":"62000.1"' in route.calls[0].request.content
+    structured = out[1]
+    assert structured["price_adjustments"] == [
+        {"field": "limit_price", "sent": "62000.07", "normalized": "62000.1"}
+    ]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_tick_rounding_skipped_when_unresolved():
+    # product lookup fails — the order must still go through with the price unchanged.
+    respx.get(f"{INDIA_TESTNET_REST}/products/BTCUSD").mock(
+        return_value=httpx.Response(500, json={"success": False, "error": {"code": "server_error"}})
+    )
+    route = respx.post(f"{INDIA_TESTNET_REST}/orders").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": {"id": 1}})
+    )
+    client = _client()
+    out = await _call(
+        client, "place_order",
+        product_symbol="BTCUSD", size=1, side="buy", order_type="limit_order", limit_price="62000.07",
+    )
+    assert b'"limit_price":"62000.07"' in route.calls[0].request.content
+    assert "price_adjustments" not in out[1]

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "delta-exchange-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Release v0.4.0: trading surface, audit log, india_devnet env.

## Added
- 13 authenticated trading tools in `tools/trading.py`, gated behind `DELTA_MCP_MODE=trade` (place/edit/cancel order, cancel-all, place/edit/cancel batch, place/edit bracket, set-leverage, change-margin, close-all, auto-topup). Every mutating tool takes `dry_run`. (#23, DEA-360)
- Audit logging (`audit_log.py`): one JSON line per mutation to `~/.delta-exchange-mcp/audit/`, `0600`, no credentials recorded. `DELTA_MCP_AUDIT` kill switch and `DELTA_MCP_AUDIT_FILE` override. `get_trading_status` tool reports mode + audit log path.
- `india_devnet` environment for `DELTA_MCP_ENV`.

## Fixed
- Batch tools now flag partial failures instead of reporting silent success (BUG-2).
- 7 value-add-layer bugs surfaced during PR #23 testing (cancel/batch/close/bracket/validate/tick-round).

## Changed
- `client.py` gains `post()`/`put()`/`delete()` with exact-body-bytes signing for POST/PUT/DELETE.

## Install

```bash
uvx "delta-exchange-mcp==0.4.0"
```
