### PR TITLE
fix(trading): reject bracket stop-loss with both fixed price and trail amount

### DIFF
--- a/src/delta_exchange_mcp/tools/trading.py
+++ b/src/delta_exchange_mcp/tools/trading.py
@@ -48,6 +48,16 @@ def _require_one(product_id: int | None, product_symbol: str | None) -> None:
         raise ValueError("pass exactly one of product_id or product_symbol")
 
 
+def _validate_bracket_sl(stop_loss_price: str | None, trail_amount: str | None) -> None:
+    """A bracket stop-loss is either a fixed trigger price or a trailing amount, never both.
+
+    Delta rejects the combination with a bad_schema error; guarding here fails fast (and in
+    dry-run) with a clearer message instead of spending a live round-trip.
+    """
+    if stop_loss_price is not None and trail_amount is not None:
+        raise ValueError("bracket stop-loss takes either a fixed price or a trailing amount, not both")
+
+
 def _validate_order(order_type: str | None, limit_price: str | None, size: int | None) -> None:
     """Client-side cross-field checks the API would otherwise only catch at send time.
 
@@ -264,6 +274,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         """
         _require_one(product_id, product_symbol)
         _validate_order(order_type, limit_price, size)
+        _validate_bracket_sl(bracket_stop_loss_price, bracket_trail_amount)
         price_fields = {
             "limit_price": limit_price,
             "stop_price": stop_price,
@@ -487,6 +498,8 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
             raise ValueError("provide at least one of stop_loss_order or take_profit_order")
         sl = _clean(stop_loss_order) if stop_loss_order else None
         tp = _clean(take_profit_order) if take_profit_order else None
+        if sl:
+            _validate_bracket_sl(sl.get("stop_price"), sl.get("trail_amount"))
         adjustments: list[dict[str, str]] = []
         for leg_name, leg in (("stop_loss_order", sl), ("take_profit_order", tp)):
             if not leg:
@@ -527,6 +540,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         tick; see price_adjustments in the response.
         """
         _require_one(product_id, product_symbol)
+        _validate_bracket_sl(bracket_stop_loss_price, bracket_trail_amount)
         price_fields = {
             "bracket_stop_loss_price": bracket_stop_loss_price,
             "bracket_stop_loss_limit_price": bracket_stop_loss_limit_price,

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -123,6 +123,40 @@ async def test_place_order_requires_exactly_one_product_ref():
 
 
 @pytest.mark.asyncio
+async def test_place_order_rejects_bracket_price_and_trail_together():
+    client = _client()
+    with pytest.raises(Exception, match="either a fixed price or a trailing amount"):
+        await _call(
+            client, "place_order",
+            product_id=27, size=1, side="buy", order_type="market_order",
+            bracket_stop_loss_price="9000", bracket_trail_amount="50", dry_run=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_edit_bracket_rejects_bracket_price_and_trail_together():
+    client = _client()
+    with pytest.raises(Exception, match="either a fixed price or a trailing amount"):
+        await _call(
+            client, "edit_bracket_order",
+            id=7, product_id=27,
+            bracket_stop_loss_price="9000", bracket_trail_amount="50", dry_run=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_place_bracket_rejects_sl_leg_price_and_trail_together():
+    client = _client()
+    with pytest.raises(Exception, match="either a fixed price or a trailing amount"):
+        await _call(
+            client, "place_bracket_order",
+            product_id=27,
+            stop_loss_order={"order_type": "market_order", "stop_price": "9000", "trail_amount": "50"},
+            dry_run=True,
+        )
+
+
+@pytest.mark.asyncio
 async def test_batch_cap_enforced():
     client = _client()
     orders = [{"size": 1, "side": "buy", "order_type": "limit_order", "limit_price": "1"}] * 51


### PR DESCRIPTION
## What

Bracket orders that specify **both** `bracket_stop_loss_price` and `bracket_trail_amount` are rejected by Delta with a `bad_schema` error ("Only bracket_stop_loss_price or bracket_trail_amount should be specified for bracket orders"). The tools passed both params through untouched, so a caller only discovered the conflict after a wasted live API round-trip.

Surfaced by a gateway log where a live `POST /v2/orders` failed exactly this way.

## Change

- Add `_validate_bracket_sl(stop_loss_price, trail_amount)` that raises `ValueError` when both are set, matching the existing `_validate_order` fail-fast pattern.
- Call it from the three bracket entry points:
  - `place_order` (`bracket_stop_loss_price` vs `bracket_trail_amount`)
  - `edit_bracket_order` (same pair)
  - `place_bracket_order` (the stop-loss leg's `stop_price` vs `trail_amount`)
- Runs before `_finish`, so `dry_run` surfaces the same failure as a real call.

## Tests

One regression test per entry point (3 new). Full trading suite: 28 passed. Lint clean.