### PR TITLE
Release v0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "delta-exchange-mcp"
-version = "0.4.0"
+version = "0.4.1"
 description = "Official MCP server for Delta Exchange India — market data and account read for AI assistants."
 readme = "README.md"
 authors = [

--- a/src/delta_exchange_mcp/tools/trading.py
+++ b/src/delta_exchange_mcp/tools/trading.py
@@ -48,6 +48,16 @@ def _require_one(product_id: int | None, product_symbol: str | None) -> None:
         raise ValueError("pass exactly one of product_id or product_symbol")
 
 
+def _validate_bracket_sl(stop_loss_price: str | None, trail_amount: str | None) -> None:
+    """A bracket stop-loss is either a fixed trigger price or a trailing amount, never both.
+
+    Delta rejects the combination with a bad_schema error; guarding here fails fast (and in
+    dry-run) with a clearer message instead of spending a live round-trip.
+    """
+    if stop_loss_price is not None and trail_amount is not None:
+        raise ValueError("bracket stop-loss takes either a fixed price or a trailing amount, not both")
+
+
 def _validate_order(order_type: str | None, limit_price: str | None, size: int | None) -> None:
     """Client-side cross-field checks the API would otherwise only catch at send time.
 
@@ -264,6 +274,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         """
         _require_one(product_id, product_symbol)
         _validate_order(order_type, limit_price, size)
+        _validate_bracket_sl(bracket_stop_loss_price, bracket_trail_amount)
         price_fields = {
             "limit_price": limit_price,
             "stop_price": stop_price,
@@ -487,6 +498,8 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
             raise ValueError("provide at least one of stop_loss_order or take_profit_order")
         sl = _clean(stop_loss_order) if stop_loss_order else None
         tp = _clean(take_profit_order) if take_profit_order else None
+        if sl:
+            _validate_bracket_sl(sl.get("stop_price"), sl.get("trail_amount"))
         adjustments: list[dict[str, str]] = []
         for leg_name, leg in (("stop_loss_order", sl), ("take_profit_order", tp)):
             if not leg:
@@ -527,6 +540,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         tick; see price_adjustments in the response.
         """
         _require_one(product_id, product_symbol)
+        _validate_bracket_sl(bracket_stop_loss_price, bracket_trail_amount)
         price_fields = {
             "bracket_stop_loss_price": bracket_stop_loss_price,
             "bracket_stop_loss_limit_price": bracket_stop_loss_limit_price,

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -123,6 +123,40 @@ async def test_place_order_requires_exactly_one_product_ref():
 
 
 @pytest.mark.asyncio
+async def test_place_order_rejects_bracket_price_and_trail_together():
+    client = _client()
+    with pytest.raises(Exception, match="either a fixed price or a trailing amount"):
+        await _call(
+            client, "place_order",
+            product_id=27, size=1, side="buy", order_type="market_order",
+            bracket_stop_loss_price="9000", bracket_trail_amount="50", dry_run=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_edit_bracket_rejects_bracket_price_and_trail_together():
+    client = _client()
+    with pytest.raises(Exception, match="either a fixed price or a trailing amount"):
+        await _call(
+            client, "edit_bracket_order",
+            id=7, product_id=27,
+            bracket_stop_loss_price="9000", bracket_trail_amount="50", dry_run=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_place_bracket_rejects_sl_leg_price_and_trail_together():
+    client = _client()
+    with pytest.raises(Exception, match="either a fixed price or a trailing amount"):
+        await _call(
+            client, "place_bracket_order",
+            product_id=27,
+            stop_loss_order={"order_type": "market_order", "stop_price": "9000", "trail_amount": "50"},
+            dry_run=True,
+        )
+
+
+@pytest.mark.asyncio
 async def test_batch_cap_enforced():
     client = _client()
     orders = [{"size": 1, "side": "buy", "order_type": "limit_order", "limit_price": "1"}] * 51

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "delta-exchange-mcp"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Promotes `develop` to `main` for the v0.4.1 release.

## Fixed
- Bracket stop-loss now rejects specifying both a fixed price and a trailing amount before hitting the API (`place_order`, `edit_bracket_order`, `place_bracket_order`). Delta returns `bad_schema` for that combo; guarding client-side fails fast and in dry-run. (#26)

## Changed
- Version bump 0.4.0 -> 0.4.1.