### PR TITLE
fix(deps): cap mcp below 2.0 so fresh installs keep the fastmcp module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "httpx>=0.28.1",
-    "mcp>=1.12.4",
+    "mcp>=1.12.4,<2",
     "pydantic>=2.13.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -194,7 +194,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "mcp", specifier = ">=1.12.4" },
+    { name = "mcp", specifier = ">=1.12.4,<2" },
     { name = "pydantic", specifier = ">=2.13.2" },
 ]
 


### PR DESCRIPTION
## What

`uvx delta-exchange-mcp` fails for every new install since 28 July:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

`server.py` imports `FastMCP` from `mcp.server.fastmcp`. The dependency is declared `mcp>=1.12.4` with no ceiling, so a fresh resolve takes the newest release — and `mcp` 2.0.0, published 2026-07-28, no longer exposes that module. The server dies at import before it can speak MCP, so the client reports nothing more useful than a failed server.

`uv.lock` pins `mcp` 1.27.0, which is why `uv sync` checkouts and already-installed copies are unaffected. `uvx` and `uv tool install` resolve from the declared ranges and ignore the lockfile. Reproduced on a cold cache against both PyPI 0.4.1 and `git+…@main` — identical failure.

This breaks the install path the README documents for every client, since Claude Code, Cursor, Codex, Windsurf, Zed and VS Code all invoke `uvx delta-exchange-mcp`.

**Every published version is affected, so there is no version to pin as a workaround.** All six declare the same unbounded range:

```
0.1.0  0.1.1  0.2.0  0.3.0  0.4.0  0.4.1   ->  mcp>=1.12.4
```

That also means the README's own `uvx "delta-exchange-mcp==0.2.0"` escape hatch fails the same way. Until a release carries this fix, the only workaround is for each user to constrain the dependency themselves: `uvx --with "mcp<2" delta-exchange-mcp`.

## Change

- `mcp>=1.12.4` → `mcp>=1.12.4,<2` in `pyproject.toml`, with the matching `uv.lock` metadata line.

`version` is left untouched — per `RELEASING.md` the bump belongs to the release cut. Worth flagging that merging alone doesn't unbreak anyone: the fix reaches `uvx` users only once a version carrying it is published to PyPI.

## Tests

Built the patched wheel and ran a fresh resolve with no lockfile in play: `uvx --from dist/delta_exchange_mcp-0.4.1-py3-none-any.whl delta-exchange-mcp` starts clean, completes an MCP handshake, resolves `mcp` 1.29.0, and registers 14 public tools (27 with credentials). 106 tests passed, ruff clean.

## Note on the 2.x line

The ceiling is deliberate but shouldn't be permanent. `mcp` 2.0 renames `FastMCP` to `MCPServer` and moves it to `mcp.server.mcpserver`, keeping `.tool()`, `.run()`, `.resource()` and `.prompt()` — bare `@mcp.tool()` decorators need no change. I spiked the migration: five source lines (one import, one constructor, three annotations) and the server runs on 2.0.0, handshakes, and serves live tool calls. `MCPServer` also takes a public `version` argument, which 1.x lacks entirely.

Two reasons I'm not proposing it here. Twelve tests read `call_tool()` as a subscriptable tuple and 2.0 returns a `CallToolResult` object, so they need rewriting before the bump has real coverage — including trading tests. And `mcp.server` in 2.0 adds substantial new surface (telemetry, caching, connection, subscriptions, elicitation) that hasn't been audited for a package that can place orders. Happy to open that as a separate PR if you want it.
