### PR TITLE
fix(cli): add --help/--version and report the package version to clients

### DIFF
--- a/src/delta_exchange_mcp/client.py
+++ b/src/delta_exchange_mcp/client.py
@@ -6,7 +6,6 @@ import hmac
 import json
 import logging
 import time
-from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 from urllib.parse import urlparse
 
@@ -14,16 +13,14 @@ import httpx
 
 from delta_exchange_mcp.config import Config
 from delta_exchange_mcp.errors import DeltaApiError
+from delta_exchange_mcp.version import PACKAGE_VERSION
 
 logger = logging.getLogger("delta_exchange_mcp")
 
 # Cap on how much of a response body we log, so a huge paginated payload can't bloat the file.
 _BODY_LOG_CAP = 50_000
 
-try:
-    USER_AGENT = f"delta-exchange-mcp/{version('delta-exchange-mcp')}"
-except PackageNotFoundError:
-    USER_AGENT = "delta-exchange-mcp/0+unknown"
+USER_AGENT = f"delta-exchange-mcp/{PACKAGE_VERSION}"
 
 
 def sign(secret: str, method: str, timestamp: str, path: str, query: str, body: str) -> str:

--- a/src/delta_exchange_mcp/debug_log.py
+++ b/src/delta_exchange_mcp/debug_log.py
@@ -16,10 +16,10 @@ import os
 import sys
 import tempfile
 import time
-from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 from delta_exchange_mcp.config import Config
+from delta_exchange_mcp.version import PACKAGE_VERSION
 
 LOGGER_NAMES = ("delta_exchange_mcp", "httpx")
 _FORMAT = "%(asctime)s %(name)s %(levelname)s %(message)s"
@@ -83,15 +83,11 @@ def configure(cfg: Config) -> Path | None:
         logger.addHandler(handler)
         logger.propagate = False  # never leak to a root/stdout handler
 
-    try:
-        pkg_version = version("delta-exchange-mcp")
-    except PackageNotFoundError:
-        pkg_version = "0+unknown"
     surface = "market+account" if cfg.has_credentials else "market"
     logging.getLogger(LOGGER_NAMES[0]).info(
         "debug log start: delta-exchange-mcp/%s env=%s base_url=%s surface=%s | "
         "credentials (api-key/secret/signature) are never logged; "
         "response bodies may contain account data",
-        pkg_version, cfg.env, cfg.base_url, surface,
+        PACKAGE_VERSION, cfg.env, cfg.base_url, surface,
     )
     return path

--- a/src/delta_exchange_mcp/server.py
+++ b/src/delta_exchange_mcp/server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import sys
 
 from mcp.server.fastmcp import FastMCP
@@ -9,11 +10,32 @@ from delta_exchange_mcp import config as config_mod
 from delta_exchange_mcp import debug_log
 from delta_exchange_mcp.client import DeltaClient
 from delta_exchange_mcp.tools import account, market, trading
+from delta_exchange_mcp.version import PACKAGE_VERSION
+
+_ENV_HELP = """\
+configuration (environment variables only — this server takes no options):
+  DELTA_MCP_ENV         india_prod (default), india_testnet, india_devnet
+  DELTA_API_KEY         optional; requires DELTA_API_SECRET for the account tools
+  DELTA_API_SECRET      required alongside DELTA_API_KEY
+  DELTA_MCP_MODE        read (default) or trade; trade registers the mutating tools
+                        when both credentials are set
+  DELTA_MCP_DEBUG       1/true/yes/on to trace HTTP requests and responses to a file
+  DELTA_MCP_DEBUG_FILE  override the debug log path
+  DELTA_MCP_AUDIT       off/false/0/no to disable the trade-mode audit log
+  DELTA_MCP_AUDIT_FILE  override the audit log path
+
+Prod and testnet API keys are separate; DELTA_MCP_ENV must match the dashboard the
+key was created on. The server speaks MCP over stdio and is normally launched by a
+client rather than by hand.
+"""
 
 
 def build_server(cfg: config_mod.Config | None = None) -> FastMCP:
     cfg = cfg or config_mod.load()
     mcp = FastMCP("delta-exchange")
+    # FastMCP has no version argument, and the server it wraps reports the mcp SDK's own
+    # version when this is left unset — so clients would see the SDK version as ours.
+    mcp._mcp_server.version = PACKAGE_VERSION
     client = DeltaClient(cfg)
 
     log_path = debug_log.configure(cfg)
@@ -51,7 +73,27 @@ def build_server(cfg: config_mod.Config | None = None) -> FastMCP:
     return mcp
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="delta-exchange-mcp",
+        description=(
+            "MCP server for Delta Exchange India: market data and account reads, "
+            "served to an MCP client over stdio."
+        ),
+        epilog=_ENV_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"delta-exchange-mcp {PACKAGE_VERSION}",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    build_parser().parse_args(argv)
+
     cfg = config_mod.load()
     mcp = build_server(cfg)
     surface = "market+account" if cfg.has_credentials else "market"

--- a/src/delta_exchange_mcp/version.py
+++ b/src/delta_exchange_mcp/version.py
@@ -1,0 +1,8 @@
+"""The installed package version, as reported to Delta and to MCP clients."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    PACKAGE_VERSION = version("delta-exchange-mcp")
+except PackageNotFoundError:  # running from a source tree that was never installed
+    PACKAGE_VERSION = "0+unknown"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,63 @@
+import pytest
+
+from delta_exchange_mcp.config import INDIA_TESTNET_REST, Config
+from delta_exchange_mcp.server import build_parser, build_server, main
+from delta_exchange_mcp.version import PACKAGE_VERSION
+
+
+def _cfg():
+    return Config(env="india_testnet", base_url=INDIA_TESTNET_REST)
+
+
+def test_help_exits_zero_and_prints_usage(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "usage: delta-exchange-mcp" in out
+    # The env vars are the whole configuration surface, so help is useless without them.
+    assert "DELTA_MCP_ENV" in out
+    assert "DELTA_API_KEY" in out
+    assert "DELTA_MCP_MODE" in out
+
+
+def test_version_flag_reports_the_package_version(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["--version"])
+    assert exc.value.code == 0
+    assert capsys.readouterr().out.strip() == f"delta-exchange-mcp {PACKAGE_VERSION}"
+
+
+def test_unknown_option_is_rejected():
+    with pytest.raises(SystemExit) as exc:
+        main(["--not-an-option"])
+    assert exc.value.code == 2
+
+
+def test_parser_help_is_not_empty():
+    assert "stdio" in build_parser().format_help()
+
+
+def test_help_documents_every_environment_variable_the_code_reads():
+    """Help is the only configuration reference, so a new env var must not slip in undocumented."""
+    import pathlib
+    import re
+
+    src = pathlib.Path(__file__).resolve().parents[1] / "src"
+    read_by_code = {
+        name
+        for path in src.rglob("*.py")
+        for name in re.findall(r"""os\.environ\.get\(["'](DELTA_[A-Z_]+)["']""", path.read_text())
+    }
+    documented = set(re.findall(r"DELTA_[A-Z_]+", build_parser().format_help()))
+    assert read_by_code, "env var scan found nothing — the pattern above stopped matching"
+    assert read_by_code <= documented, f"undocumented in --help: {sorted(read_by_code - documented)}"
+
+
+def test_handshake_reports_our_version_not_the_sdk_version():
+    """Left unset, the wrapped server falls back to reporting the mcp SDK's version as ours."""
+    from importlib.metadata import version
+
+    opts = build_server(_cfg())._mcp_server.create_initialization_options()
+    assert opts.server_version == PACKAGE_VERSION
+    assert opts.server_version != version("mcp")


### PR DESCRIPTION
## What

Two things the server reports about itself are wrong.

**`--help` prints no help.** The README cites `uvx delta-exchange-mcp --help` in three places as the way to sanity-check an install, but `main()` never inspects `sys.argv`. The flag is ignored: the process prints its startup banner, begins serving stdio, and exits 0 when stdin closes. A user runs the documented check, sees one line, and learns nothing — and unknown flags are silently swallowed the same way.

**The version reported to clients is the SDK's, not ours.** The server the SDK wraps computes what it advertises as `self.version if self.version else pkg_version("mcp")`, and `FastMCP` never sets it. So a handshake against 0.4.1 returns:

```
serverInfo: {'name': 'delta-exchange', 'version': '1.27.0'}
```

That's the `mcp` version. Two installs of the same release disagree depending on which SDK got resolved — I saw both `1.27.0` and `1.29.0` from 0.4.1 — which makes any version quoted in a bug report misleading.

## Change

- `--help` / `-h` prints usage and exits 0; `--version` prints `delta-exchange-mcp <version>`; an unrecognized flag exits 2. Help lists every environment variable, since those are the entire configuration surface and help is useless without them. It also states that prod and testnet keys are separate, which is the most common cause of a 401 on first use.
- `build_server` sets the wrapped server's version to the package version, so handshakes report `0.4.1`.
- New `version.py` holds the package version as one constant. The same `importlib.metadata` lookup with the same `"0+unknown"` fallback was already written out twice — once for the outgoing `User-Agent` header, once for the debug log's opening line — and setting the server version needed a third. Those are now one constant with three consumers; one `importlib.metadata` import remains in the tree.

On the private attribute: `FastMCP` accepts no `version` argument, has no `**kwargs`, and exposes the wrapped server only as `_mcp_server` — I checked 1.27.0 and 1.29.0, so there is no public route anywhere in the 1.x line. The assignment carries a comment saying why. If you'd rather not carry it, say so and I'll drop it and keep only the `--help` change; it becomes a plain constructor argument if the package ever moves to `mcp` 2.x.

## Tests

Five new tests: `--help` exits 0 and its output names the env vars, `--version` matches the package version, an unknown flag exits 2, the parser's help is non-empty, and a built server's initialization options carry the package version rather than the SDK's.

111 passed, ruff clean. Verified against the real binary: `--help` prints the usage block, `--version` prints `delta-exchange-mcp 0.4.1`, `--bogus` exits 2, and a live handshake now reports `version: '0.4.1'`. `python -m delta_exchange_mcp --version` works too.
