### PR TITLE
docs(readme): document the Codex desktop app form

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Global: `~/.cursor/mcp.json` (or `%USERPROFILE%\.cursor\mcp.json` on Windows). P
 
 Restart Cursor or open **Settings → Tools & MCP** to refresh.
 
-### Codex
+### Codex CLI
 
 Add to `~/.codex/config.toml`:
 
@@ -72,6 +72,19 @@ command = "uvx"
 args = ["delta-exchange-mcp"]
 env = { DELTA_MCP_ENV = "india_prod", DELTA_API_KEY = "your-api-key", DELTA_API_SECRET = "your-api-secret" }
 ```
+
+### Codex desktop app
+
+To add the server from the app's UI, go to **Plugins → MCPs → Connect to a custom MCP**, leave **Type** as STDIO, and fill in:
+
+| Field | Value |
+|---|---|
+| Name | `delta-exchange-mcp` |
+| Command to launch | `uvx` (`uvx.exe` on Windows) |
+| Arguments | `delta-exchange-mcp` |
+| Environment variables | `DELTA_MCP_ENV` = `india_prod`, `DELTA_API_KEY` = your-api-key, `DELTA_API_SECRET` = your-api-secret |
+
+Leave the other fields empty, then restart the app.
 
 ### Windsurf
 


### PR DESCRIPTION
## What

The Codex section covers `~/.codex/config.toml`, which is the CLI. The desktop app doesn't read that file — it takes MCP servers through a form under **Plugins → MCPs → Connect to a custom MCP** — so anyone using the app has to work out for themselves how the TOML snippet maps onto Name / Command / Arguments / Env fields.

Windsurf already gets a UI-route line for its equivalent; Codex had nothing.

## Change

- Renamed `### Codex` to `### Codex CLI`, so it's clear which of the two it covers.
- Added `### Codex desktop app`: a field-by-field table with the same values as the CLI snippet directly above it.

No anchors pointed at the old `#codex` heading and there's no table of contents, so the rename breaks no links.

## Tests

Docs only. Re-parsed every fenced block in the README — 18 blocks, all valid JSON/TOML, every client snippet still reducing to the same `uvx delta-exchange-mcp` spawn.
