### PR TITLE
fix(deps): bound httpx and pydantic, document the mcp 2.0 install failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Sanity-check the install:
 uvx delta-exchange-mcp --help
 ```
 
-The server runs **local stdio only**: your MCP client launches it as a subprocess, and your API keys never leave your machine. `uvx` resolves the latest published version from PyPI on each launch. To pin a specific version, use `uvx "delta-exchange-mcp==0.2.0"`.
+The server runs **local stdio only**: your MCP client launches it as a subprocess, and your API keys never leave your machine. `uvx` resolves the latest published version from PyPI on each launch. To pin a specific version, use `uvx "delta-exchange-mcp==0.4.2"`. Pin `0.4.2` or newer: earlier versions do not start on a fresh install (see [Troubleshooting](#troubleshooting)).
 
 ## Install in your MCP client
 
@@ -239,7 +239,7 @@ Register the dev server under a separate name (e.g. `delta-exchange-mcp-dev`) so
 
 `uvx` caches the resolved package, so a new PyPI release isn't picked up automatically. To move to the latest version:
 
-1. **If your config pins a version** (`uvx "delta-exchange-mcp==0.1.1"`), bump the pin to the new version, or drop it to float to latest.
+1. **If your config pins a version** (`uvx "delta-exchange-mcp==0.4.2"`), bump the pin to the new version, or drop it to float to latest.
 2. **Refresh the `uvx` cache** so it fetches the new build:
 
    ```bash
@@ -268,6 +268,38 @@ New tools appear only after the respawn. The MCP `list_changed` notification ref
 | `DELTA_MCP_DEBUG_FILE` | _(auto)_ | Override the debug log path. Default: `~/.delta-exchange-mcp/logs/debug-<timestamp>-<pid>.log`. |
 | `DELTA_MCP_AUDIT` | _(on in trade mode)_ | Set `off`/`false`/`0`/`no` to disable the trading audit log. On by default whenever `DELTA_MCP_MODE=trade`. |
 | `DELTA_MCP_AUDIT_FILE` | _(auto)_ | Override the audit log path. Default: `~/.delta-exchange-mcp/audit/audit-<timestamp>-<pid>.log`. |
+
+## Troubleshooting
+
+### `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`
+
+Your client shows the server as failed, and the process writes this traceback to stderr.
+
+Version 0.4.1 and all earlier versions declare `mcp>=1.12.4` with no upper limit. The `mcp`
+package published 2.0.0 on 28 July 2026, and 2.0.0 removed the `mcp.server.fastmcp` module.
+`uvx` resolves from the declared range and ignores `uv.lock`, so a fresh install gets 2.0.0
+and the server stops at import. Existing installs and `uv sync` checkouts are not affected.
+
+Move to 0.4.2 or a newer version, which sets an upper limit of `mcp<2`:
+
+```bash
+uvx --refresh delta-exchange-mcp --help
+```
+
+To stay on an older version, set the limit yourself:
+
+```bash
+uvx --with "mcp<2" "delta-exchange-mcp==0.4.1"
+```
+
+Add the same `--with` argument to your MCP client config if you pin an older version there:
+
+```jsonc
+"delta-exchange": {
+  "command": "uvx",
+  "args": ["--with", "mcp<2", "delta-exchange-mcp==0.4.1"]
+}
+```
 
 ## Debugging / reporting a bug
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,9 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "httpx>=0.28.1",
+    "httpx>=0.28.1,<1",
     "mcp>=1.12.4,<2",
-    "pydantic>=2.13.2",
+    "pydantic>=2.13.2,<3",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "httpx>=0.28.1",
-    "mcp>=1.12.4",
+    "mcp>=1.12.4,<2",
     "pydantic>=2.13.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -194,7 +194,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "mcp", specifier = ">=1.12.4" },
+    { name = "mcp", specifier = ">=1.12.4,<2" },
     { name = "pydantic", specifier = ">=2.13.2" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -193,9 +193,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx", specifier = ">=0.28.1,<1" },
     { name = "mcp", specifier = ">=1.12.4,<2" },
-    { name = "pydantic", specifier = ">=2.13.2" },
+    { name = "pydantic", specifier = ">=2.13.2,<3" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
> Stacked on #30. Merge #30 first, then this branch shows a 3-file diff.

## What

#30 puts an upper limit on `mcp` after 2.0.0 broke every fresh install. Two follow-ups from validating it:

**The other two dependencies carry the same risk shape.** `httpx>=0.28.1` and `pydantic>=2.13.2` have no upper limit either, so the next major release of either reaches `uvx` users the day it lands on PyPI, untested. Neither is a risk right now (latest are `0.28.1` and `2.13.4`), which is exactly why this is cheap to do now instead of during the next outage.

**The README documents install commands that no longer work.** Two places offer a pinned install as the way to hold a version:

- Line 24: `uvx "delta-exchange-mcp==0.2.0"`
- Line 242: `uvx "delta-exchange-mcp==0.1.1"`

Every published version declares `mcp>=1.12.4`, so both of those fail with the same `ModuleNotFoundError`. Anyone who hits the break and reaches for the documented escape hatch lands on a second copy of the break, with nothing telling them why.

## Change

- `httpx>=0.28.1` -> `httpx>=0.28.1,<1` and `pydantic>=2.13.2` -> `pydantic>=2.13.2,<3`, with the matching `uv.lock` metadata lines from `uv sync`. No resolved version moves; the lockfile diff is 2 lines.
- New `## Troubleshooting` section in the README for the `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` failure: what causes it, why `uv sync` checkouts are unaffected, and the `uvx --with "mcp<2"` workaround in both CLI and MCP-client-config form.
- Both pinned-version examples moved to `0.4.2`, and the quick-start line now says to pin `0.4.2` or newer.

`version` is untouched, per `RELEASING.md`.

## Ordering

The Troubleshooting section tells users to run `uvx --refresh delta-exchange-mcp --help` to pick up the fix. That command only prints anything after #31, which makes `--help` real. All three PRs belong in 0.4.2, so the text is correct at release, but this should not ship in a release without #31.

## Tests

`106 passed`, `ruff check src tests scripts` clean, `uv lock --check` reports the lockfile in sync.

Built the wheel and did a fresh resolve with no lockfile in play. All three limits hold and the server registers its tools:

```
mcp 1.29.0
httpx 0.28.1
pydantic 2.13.4
tools: 14
```

Also ran the suite against `mcp==1.29.0`, the top of the permitted range rather than the `1.27.0` the lockfile pins: `106 passed`. Prereleases are not selected, so `2.0.0rc1` stays out.
