### PR TITLE
Release v0.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Sanity-check the install:
 uvx delta-exchange-mcp --help
 ```
 
-The server runs **local stdio only**: your MCP client launches it as a subprocess, and your API keys never leave your machine. `uvx` resolves the latest published version from PyPI on each launch. To pin a specific version, use `uvx "delta-exchange-mcp==0.2.0"`.
+The server runs **local stdio only**: your MCP client launches it as a subprocess, and your API keys never leave your machine. `uvx` resolves the latest published version from PyPI on each launch. To pin a specific version, use `uvx "delta-exchange-mcp==0.4.2"`. Pin `0.4.2` or newer: earlier versions do not start on a fresh install (see [Troubleshooting](#troubleshooting)).
 
 ## Install in your MCP client
 
@@ -239,7 +239,7 @@ Register the dev server under a separate name (e.g. `delta-exchange-mcp-dev`) so
 
 `uvx` caches the resolved package, so a new PyPI release isn't picked up automatically. To move to the latest version:
 
-1. **If your config pins a version** (`uvx "delta-exchange-mcp==0.1.1"`), bump the pin to the new version, or drop it to float to latest.
+1. **If your config pins a version** (`uvx "delta-exchange-mcp==0.4.2"`), bump the pin to the new version, or drop it to float to latest.
 2. **Refresh the `uvx` cache** so it fetches the new build:
 
    ```bash
@@ -268,6 +268,38 @@ New tools appear only after the respawn. The MCP `list_changed` notification ref
 | `DELTA_MCP_DEBUG_FILE` | _(auto)_ | Override the debug log path. Default: `~/.delta-exchange-mcp/logs/debug-<timestamp>-<pid>.log`. |
 | `DELTA_MCP_AUDIT` | _(on in trade mode)_ | Set `off`/`false`/`0`/`no` to disable the trading audit log. On by default whenever `DELTA_MCP_MODE=trade`. |
 | `DELTA_MCP_AUDIT_FILE` | _(auto)_ | Override the audit log path. Default: `~/.delta-exchange-mcp/audit/audit-<timestamp>-<pid>.log`. |
+
+## Troubleshooting
+
+### `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`
+
+Your client shows the server as failed, and the process writes this traceback to stderr.
+
+Version 0.4.1 and all earlier versions declare `mcp>=1.12.4` with no upper limit. The `mcp`
+package published 2.0.0 on 28 July 2026, and 2.0.0 removed the `mcp.server.fastmcp` module.
+`uvx` resolves from the declared range and ignores `uv.lock`, so a fresh install gets 2.0.0
+and the server stops at import. Existing installs and `uv sync` checkouts are not affected.
+
+Move to 0.4.2 or a newer version, which sets an upper limit of `mcp<2`:
+
+```bash
+uvx --refresh delta-exchange-mcp --help
+```
+
+To stay on an older version, set the limit yourself:
+
+```bash
+uvx --with "mcp<2" "delta-exchange-mcp==0.4.1"
+```
+
+Add the same `--with` argument to your MCP client config if you pin an older version there:
+
+```jsonc
+"delta-exchange": {
+  "command": "uvx",
+  "args": ["--with", "mcp<2", "delta-exchange-mcp==0.4.1"]
+}
+```
 
 ## Debugging / reporting a bug
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "delta-exchange-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "Official MCP server for Delta Exchange India — market data and account read for AI assistants."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,9 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "httpx>=0.28.1",
+    "httpx>=0.28.1,<1",
     "mcp>=1.12.4,<2",
-    "pydantic>=2.13.2",
+    "pydantic>=2.13.2,<3",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "httpx>=0.28.1",
-    "mcp>=1.12.4",
+    "mcp>=1.12.4,<2",
     "pydantic>=2.13.2",
 ]
 

--- a/src/delta_exchange_mcp/client.py
+++ b/src/delta_exchange_mcp/client.py
@@ -6,7 +6,6 @@ import hmac
 import json
 import logging
 import time
-from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 from urllib.parse import urlparse
 
@@ -14,16 +13,14 @@ import httpx
 
 from delta_exchange_mcp.config import Config
 from delta_exchange_mcp.errors import DeltaApiError
+from delta_exchange_mcp.version import PACKAGE_VERSION
 
 logger = logging.getLogger("delta_exchange_mcp")
 
 # Cap on how much of a response body we log, so a huge paginated payload can't bloat the file.
 _BODY_LOG_CAP = 50_000
 
-try:
-    USER_AGENT = f"delta-exchange-mcp/{version('delta-exchange-mcp')}"
-except PackageNotFoundError:
-    USER_AGENT = "delta-exchange-mcp/0+unknown"
+USER_AGENT = f"delta-exchange-mcp/{PACKAGE_VERSION}"
 
 
 def sign(secret: str, method: str, timestamp: str, path: str, query: str, body: str) -> str:

--- a/src/delta_exchange_mcp/debug_log.py
+++ b/src/delta_exchange_mcp/debug_log.py
@@ -16,10 +16,10 @@ import os
 import sys
 import tempfile
 import time
-from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 from delta_exchange_mcp.config import Config
+from delta_exchange_mcp.version import PACKAGE_VERSION
 
 LOGGER_NAMES = ("delta_exchange_mcp", "httpx")
 _FORMAT = "%(asctime)s %(name)s %(levelname)s %(message)s"
@@ -83,15 +83,11 @@ def configure(cfg: Config) -> Path | None:
         logger.addHandler(handler)
         logger.propagate = False  # never leak to a root/stdout handler
 
-    try:
-        pkg_version = version("delta-exchange-mcp")
-    except PackageNotFoundError:
-        pkg_version = "0+unknown"
     surface = "market+account" if cfg.has_credentials else "market"
     logging.getLogger(LOGGER_NAMES[0]).info(
         "debug log start: delta-exchange-mcp/%s env=%s base_url=%s surface=%s | "
         "credentials (api-key/secret/signature) are never logged; "
         "response bodies may contain account data",
-        pkg_version, cfg.env, cfg.base_url, surface,
+        PACKAGE_VERSION, cfg.env, cfg.base_url, surface,
     )
     return path

--- a/src/delta_exchange_mcp/server.py
+++ b/src/delta_exchange_mcp/server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import sys
 
 from mcp.server.fastmcp import FastMCP
@@ -9,11 +10,32 @@ from delta_exchange_mcp import config as config_mod
 from delta_exchange_mcp import debug_log
 from delta_exchange_mcp.client import DeltaClient
 from delta_exchange_mcp.tools import account, market, trading
+from delta_exchange_mcp.version import PACKAGE_VERSION
+
+_ENV_HELP = """\
+configuration (environment variables only — this server takes no options):
+  DELTA_MCP_ENV         india_prod (default), india_testnet, india_devnet
+  DELTA_API_KEY         optional; requires DELTA_API_SECRET for the account tools
+  DELTA_API_SECRET      required alongside DELTA_API_KEY
+  DELTA_MCP_MODE        read (default) or trade; trade registers the mutating tools
+                        when both credentials are set
+  DELTA_MCP_DEBUG       1/true/yes/on to trace HTTP requests and responses to a file
+  DELTA_MCP_DEBUG_FILE  override the debug log path
+  DELTA_MCP_AUDIT       off/false/0/no to disable the trade-mode audit log
+  DELTA_MCP_AUDIT_FILE  override the audit log path
+
+Prod and testnet API keys are separate; DELTA_MCP_ENV must match the dashboard the
+key was created on. The server speaks MCP over stdio and is normally launched by a
+client rather than by hand.
+"""
 
 
 def build_server(cfg: config_mod.Config | None = None) -> FastMCP:
     cfg = cfg or config_mod.load()
     mcp = FastMCP("delta-exchange")
+    # FastMCP has no version argument, and the server it wraps reports the mcp SDK's own
+    # version when this is left unset — so clients would see the SDK version as ours.
+    mcp._mcp_server.version = PACKAGE_VERSION
     client = DeltaClient(cfg)
 
     log_path = debug_log.configure(cfg)
@@ -51,7 +73,27 @@ def build_server(cfg: config_mod.Config | None = None) -> FastMCP:
     return mcp
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="delta-exchange-mcp",
+        description=(
+            "MCP server for Delta Exchange India: market data and account reads, "
+            "served to an MCP client over stdio."
+        ),
+        epilog=_ENV_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"delta-exchange-mcp {PACKAGE_VERSION}",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    build_parser().parse_args(argv)
+
     cfg = config_mod.load()
     mcp = build_server(cfg)
     surface = "market+account" if cfg.has_credentials else "market"

--- a/src/delta_exchange_mcp/version.py
+++ b/src/delta_exchange_mcp/version.py
@@ -1,0 +1,8 @@
+"""The installed package version, as reported to Delta and to MCP clients."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    PACKAGE_VERSION = version("delta-exchange-mcp")
+except PackageNotFoundError:  # running from a source tree that was never installed
+    PACKAGE_VERSION = "0+unknown"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,63 @@
+import pytest
+
+from delta_exchange_mcp.config import INDIA_TESTNET_REST, Config
+from delta_exchange_mcp.server import build_parser, build_server, main
+from delta_exchange_mcp.version import PACKAGE_VERSION
+
+
+def _cfg():
+    return Config(env="india_testnet", base_url=INDIA_TESTNET_REST)
+
+
+def test_help_exits_zero_and_prints_usage(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "usage: delta-exchange-mcp" in out
+    # The env vars are the whole configuration surface, so help is useless without them.
+    assert "DELTA_MCP_ENV" in out
+    assert "DELTA_API_KEY" in out
+    assert "DELTA_MCP_MODE" in out
+
+
+def test_version_flag_reports_the_package_version(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["--version"])
+    assert exc.value.code == 0
+    assert capsys.readouterr().out.strip() == f"delta-exchange-mcp {PACKAGE_VERSION}"
+
+
+def test_unknown_option_is_rejected():
+    with pytest.raises(SystemExit) as exc:
+        main(["--not-an-option"])
+    assert exc.value.code == 2
+
+
+def test_parser_help_is_not_empty():
+    assert "stdio" in build_parser().format_help()
+
+
+def test_help_documents_every_environment_variable_the_code_reads():
+    """Help is the only configuration reference, so a new env var must not slip in undocumented."""
+    import pathlib
+    import re
+
+    src = pathlib.Path(__file__).resolve().parents[1] / "src"
+    read_by_code = {
+        name
+        for path in src.rglob("*.py")
+        for name in re.findall(r"""os\.environ\.get\(["'](DELTA_[A-Z_]+)["']""", path.read_text())
+    }
+    documented = set(re.findall(r"DELTA_[A-Z_]+", build_parser().format_help()))
+    assert read_by_code, "env var scan found nothing — the pattern above stopped matching"
+    assert read_by_code <= documented, f"undocumented in --help: {sorted(read_by_code - documented)}"
+
+
+def test_handshake_reports_our_version_not_the_sdk_version():
+    """Left unset, the wrapped server falls back to reporting the mcp SDK's version as ours."""
+    from importlib.metadata import version
+
+    opts = build_server(_cfg())._mcp_server.create_initialization_options()
+    assert opts.server_version == PACKAGE_VERSION
+    assert opts.server_version != version("mcp")

--- a/uv.lock
+++ b/uv.lock
@@ -194,7 +194,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "mcp", specifier = ">=1.12.4" },
+    { name = "mcp", specifier = ">=1.12.4,<2" },
     { name = "pydantic", specifier = ">=2.13.2" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -193,9 +193,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx", specifier = ">=0.28.1,<1" },
     { name = "mcp", specifier = ">=1.12.4,<2" },
-    { name = "pydantic", specifier = ">=2.13.2" },
+    { name = "pydantic", specifier = ">=2.13.2,<3" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "delta-exchange-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Release v0.4.2. Promotes three fixes from `develop`.

## Fixed

- **Fresh installs were broken since 28 July.** `mcp` 2.0.0 removed `mcp.server.fastmcp`, and the dependency had no upper limit, so every `uvx delta-exchange-mcp` resolved 2.0.0 and stopped at import with `ModuleNotFoundError`. Every published version 0.1.0 through 0.4.1 is affected, so no earlier version worked as a fallback. #30
- **`--help` printed no help.** The README cites `uvx delta-exchange-mcp --help` as the install check in three places, but `main()` never read `sys.argv`. The flag was ignored and the process just began serving stdio. `--help` and `--version` now work, and an unknown flag exits 2. #31
- **Clients were told the SDK's version, not ours.** A handshake against 0.4.1 returned `version: 1.27.0`, the resolved `mcp` version, so any version quoted in a bug report was wrong. Handshakes now report the package version. #31

## Changed

- `httpx` and `pydantic` now carry `<1` and `<3` upper limits. Both had the same unbounded range that let `mcp` 2.0.0 through. No resolved version moves. #33

## Added

- README `## Troubleshooting` section for the `ModuleNotFoundError`, with the `uvx --with "mcp<2"` workaround for anyone stuck on an older version. Both pinned-version examples in the README pointed at versions that no longer start, and now point at 0.4.2. #33

## Verification

`112 passed`, ruff clean, `uv lock --check` in sync. Cold resolve of the built wheel with no lockfile in play gets `mcp 1.29.0`, `httpx 0.28.1`, `pydantic 2.13.4` and registers 14 public tools. Suite also passes against `mcp==1.29.0`, the top of the permitted range, not just the `1.27.0` the lockfile pins.

## Not in this release

- #32 (Codex desktop app docs) is docs-only and can go in the next cut. It touches the README, so it will need a rebase over the Troubleshooting section.
- The `mcp` 2.x migration. The `<2` limit is deliberate but should not be permanent. 2.x renames `FastMCP` to `MCPServer` and takes a public `version` argument, which would remove the private-attribute write #31 had to add. Twelve tests read `call_tool()` as a tuple and 2.x returns a `CallToolResult`, so they need rewriting first.
