### PR TITLE
docs(readme): add a copyable prompt so a coding agent can do the install

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,33 @@ The server runs **local stdio only**: your MCP client launches it as a subproces
 
 `DELTA_API_KEY` / `DELTA_API_SECRET` are **optional** in every snippet below — drop them for public-data-only mode. Set `DELTA_MCP_ENV=india_testnet` for testnet.
 
+### Let your coding agent set it up
+
+Copy this into Claude Code, Codex, Cursor, or any agent that can edit files on your machine:
+
+```text
+Set up the Delta Exchange MCP server for me.
+
+Read https://raw.githubusercontent.com/delta-exchange/delta-exchange-mcp/main/README.md
+and follow the "Install in your MCP client" section for the client I am using. If you
+cannot tell which client that is, ask me.
+
+Rules:
+- Add a server entry named delta-exchange-mcp. Do not modify or remove any other MCP
+  server I already have configured.
+- Write the literal placeholders your-api-key and your-api-secret. Do not ask me for my
+  real API keys, and do not repeat them back to me. I will fill them in myself.
+- Use DELTA_MCP_ENV=india_prod unless I tell you testnet.
+- Check your work by running: uvx delta-exchange-mcp --version
+  Do not run the server without arguments. It serves over stdio and will not exit.
+- If that command fails with an import error, follow the README's Troubleshooting section.
+- Tell me which file you changed, and that I need to restart the client.
+```
+
+Your agent writes placeholder credentials, never your real ones. Open the file it names,
+replace `your-api-key` and `your-api-secret` with your keys from the Delta dashboard, then
+restart the client. To set it up by hand instead, follow the steps for your client below.
+
 ### Claude Code
 
 ```bash


### PR DESCRIPTION
## What

Installing this server means picking your client out of a list, finding the right config file, and getting the JSON or TOML shape right. Most people asking for it already have a coding agent open that could just do it.

This adds a copyable prompt to the top of "Install in your MCP client". Paste it into Claude Code, Codex, Cursor, or anything else that can edit files, and the agent does the install.

## Change

One new subsection ahead of the per-client list, containing the prompt block and three lines telling the reader what to do afterwards.

Four things in the prompt are deliberate:

**It points at the README rather than restating config.** The prompt tells the agent to read the raw README and follow the section for whichever client it's in. A prompt that embedded commands and file paths would drift — this file changed three times today alone — and a stale prompt makes an agent confidently write a wrong config. This way the agent works from the project's own instructions and the prompt never needs updating, including when 0.4.2 reaches PyPI and the Troubleshooting advice stops applying.

**It never handles real credentials.** The agent is told to write the literal `your-api-key` / `your-api-secret` placeholders, not to ask for the real ones, and not to repeat them back. The user edits the file afterwards. Keys pasted into an agent chat end up in a transcript, a provider's logs, and possibly shell history — for a key that can place orders on a live exchange, that's worth one manual step to avoid.

**It forbids running the server bare.** `uvx delta-exchange-mcp` with no arguments serves over stdio and never exits, so an agent running it to "check" hangs itself and then starts debugging a problem that isn't there. The prompt specifies `--version`, which prints and exits.

**It tells the agent not to touch other servers.** These config files routinely hold ten other MCP entries. One careless rewrite costs someone their whole setup.

## Tests

Docs only, but the prompt's factual claims are verified rather than assumed:

- the raw README URL returns HTTP 200
- both section names it cites, "Install in your MCP client" and "Troubleshooting", exist on `main`
- `uvx delta-exchange-mcp --version` is useful in both states: against the currently published 0.4.1 it surfaces the `ModuleNotFoundError`, which is exactly what routes the agent to Troubleshooting; against 0.4.2 it prints the version and exits 0
- a bare `delta-exchange-mcp` on a pipe was still running at a 5s timeout, confirming the warning about it not exiting

Every fenced block in the README still parses.

Not yet verified end to end by actually pasting the prompt into a fresh agent against a clean machine — worth doing before merge if you want it.
