### PR TITLE
fix(scripts): make inspect.sh work with MCP Inspector v2

### DIFF
--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -3,32 +3,42 @@
 #
 # Two modes:
 #
-#   Web UI mode (default) — opens UI on :6274 and proxy on :6277.
+#   Web UI mode (default) - opens UI on :6274 and proxy on :6277.
 #     bash scripts/inspect.sh
 #   With creds:
 #     DELTA_API_KEY=... DELTA_API_SECRET=... bash scripts/inspect.sh
 #
-#   CLI mode — headless, works over SSH (no browser needed).
+#   CLI mode - headless, works over SSH (no browser needed).
 #     bash scripts/inspect.sh --cli --method tools/list
 #     bash scripts/inspect.sh --cli --method tools/call \
 #       --tool-name get_ticker --tool-arg symbol=BTCUSD
 #
-# Note: the Inspector treats everything before its own flags as the server
-# command. So the correct invocation is:
-#   npx ... inspector [-e KEY=VAL ...] <server-cmd> [<server-args>...] [--method ...] [--cli]
+# Inspector v2 wants the mode flag first and the server command before every option,
+# so the layout is:
+#   inspector <mode> <server-cmd> [<server-args>...] [-e KEY=VAL ...] [--method ...]
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
 export PATH="$HOME/.local/bin:$PATH"
 
-# Bind to 0.0.0.0 so Tailscale clients can open the UI. Comment this out if
-# you'd rather SSH port-forward (ssh -L 6274:localhost:6274 <host>).
-export HOST="${HOST:-0.0.0.0}"
+# v1 took the mode flag last. v2 forwards a trailing --cli to the server, so the web UI
+# opened instead of the CLI and the server exited 2 on the unknown flag.
+MODE="--web"
+case "${1:-}" in
+  --cli|--tui|--web)
+    MODE="$1"
+    shift
+    ;;
+esac
+
+# The Inspector refuses to bind 0.0.0.0: its backend spawns local processes, which is what
+# DNS-rebinding attacks target. For remote access: ssh -L 6274:localhost:6274 <host>
+export HOST="${HOST:-127.0.0.1}"
 export CLIENT_PORT="${CLIENT_PORT:-6274}"
 export SERVER_PORT="${SERVER_PORT:-6277}"
 
 ENV_ARGS=(
-  -e "DELTA_MCP_ENV=${DELTA_MCP_ENV:-testnet}"
+  -e "DELTA_MCP_ENV=${DELTA_MCP_ENV:-india_testnet}"
   -e "DELTA_MCP_MODE=${DELTA_MCP_MODE:-read}"
 )
 if [[ -n "${DELTA_API_KEY:-}" ]]; then
@@ -39,6 +49,7 @@ if [[ -n "${DELTA_API_SECRET:-}" ]]; then
 fi
 
 exec npx --yes @modelcontextprotocol/inspector \
-  "${ENV_ARGS[@]}" \
+  "$MODE" \
   uv run delta-exchange-mcp \
+  "${ENV_ARGS[@]}" \
   "$@"


### PR DESCRIPTION
## What

`bash scripts/inspect.sh --cli --method tools/list` does not work. It opens the web UI instead of running the CLI, and the server it launches fails immediately:

```
uv run delta-exchange-mcp --cli --method tools/list
delta-exchange-mcp: error: unrecognized arguments: --cli --method tools/list
```

Three separate breaks, all pre-existing. They surfaced now because #31 made the server reject unknown arguments instead of ignoring them, so what used to be a silent wrong result is a visible failure.

**The argument layout is wrong for Inspector v2.** v2 says `Mode flags (--web, --cli, --tui) must appear before app options. All following arguments are forwarded unchanged.` The script passed `"$@"` last, so a trailing `--cli` was forwarded to the server rather than read by the Inspector. Before #31 the server swallowed it and started anyway, which is worse than the current failure: the web UI opened, `--method tools/list` never ran, and nothing said so.

The `-e` pairs had to move as well. Placed before the server command, v2 loses the target and falls back to a config file:

```
{"error":{"code":"error","message":"No servers found in config file"}}
```

I probed the layouts to confirm. Only one works: mode flag first, server command next, then all options.

| Layout | Result |
| --- | --- |
| `--cli -e K=V uvx delta-exchange-mcp --method tools/list` | No servers found in config file |
| `--cli -e K=V --method tools/list uvx delta-exchange-mcp` | No servers found in config file |
| `--cli uvx delta-exchange-mcp -e K=V --method tools/list` | works |

**`HOST` defaulted to `0.0.0.0`, which v2 refuses to bind.**

```
Error: Refusing to bind HOST="0.0.0.0": this exposes the MCP Inspector to your entire
network, and its backend can spawn local processes and connect to MCP servers on your
behalf - the exposure DNS-rebinding attacks target.
```

The refusal is right, so the fix is to stop asking for it rather than set the override.

**`DELTA_MCP_ENV` defaulted to `testnet`, which is not a valid value.** `config.load()` accepts only `india_prod`, `india_testnet`, `india_devnet` and raises `ValueError` on anything else. Broken since the env values were renamed.

## Change

- Mode flag (`--cli` / `--tui` / `--web`) is read off the front of `"$@"` and passed first. Default stays web mode.
- Server command now comes before the `-e` pairs and before the forwarded arguments.
- `HOST` defaults to `127.0.0.1`, still overridable. The comment points at `ssh -L` for remote access instead.
- `DELTA_MCP_ENV` defaults to `india_testnet`.

The script's own interface is unchanged, so every call site in `README.md`, `CLAUDE.md` and `RELEASING.md` keeps working exactly as written. This matters for `RELEASING.md`, whose post-release verification calls `inspect.sh --cli` and has therefore not been doing anything useful.

## Tests

Both documented CLI invocations, against the real server:

```
bash scripts/inspect.sh --cli --method tools/list
  -> tools: 14

DELTA_MCP_ENV=india_prod bash scripts/inspect.sh --cli --method tools/call \
  --tool-name get_ticker --tool-arg symbol=BTCUSD
  -> isError: False | symbol: BTCUSD | spot: 64827.2
```

The default (no `DELTA_MCP_ENV`) resolves testnet and lists 14 tools, so the invalid-value crash is gone.

Web mode launches and serves:

```
client :6274 -> 200
proxy  :6277 -> 404   (expected on /)
```

No source or test changes, so the Python suite is untouched at `112 passed`.
