### PR TITLE
Promote docs and inspect.sh fix to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,33 @@ The server runs **local stdio only**: your MCP client launches it as a subproces
 
 `DELTA_API_KEY` / `DELTA_API_SECRET` are **optional** in every snippet below — drop them for public-data-only mode. Set `DELTA_MCP_ENV=india_testnet` for testnet.
 
+### Let your coding agent set it up
+
+Copy this into Claude Code, Codex, Cursor, or any agent that can edit files on your machine:
+
+```text
+Set up the Delta Exchange MCP server for me.
+
+Read https://raw.githubusercontent.com/delta-exchange/delta-exchange-mcp/main/README.md
+and follow the "Install in your MCP client" section for the client I am using. If you
+cannot tell which client that is, ask me.
+
+Rules:
+- Add a server entry named delta-exchange-mcp. Do not modify or remove any other MCP
+  server I already have configured.
+- Write the literal placeholders your-api-key and your-api-secret. Do not ask me for my
+  real API keys, and do not repeat them back to me. I will fill them in myself.
+- Use DELTA_MCP_ENV=india_prod unless I tell you testnet.
+- Check your work by running: uvx delta-exchange-mcp --version
+  Do not run the server without arguments. It serves over stdio and will not exit.
+- If that command fails with an import error, follow the README's Troubleshooting section.
+- Tell me which file you changed, and that I need to restart the client.
+```
+
+Your agent writes placeholder credentials, never your real ones. Open the file it names,
+replace `your-api-key` and `your-api-secret` with your keys from the Delta dashboard, then
+restart the client. To set it up by hand instead, follow the steps for your client below.
+
 ### Claude Code
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Global: `~/.cursor/mcp.json` (or `%USERPROFILE%\.cursor\mcp.json` on Windows). P
 
 Restart Cursor or open **Settings → Tools & MCP** to refresh.
 
-### Codex
+### Codex CLI
 
 Add to `~/.codex/config.toml`:
 
@@ -72,6 +72,19 @@ command = "uvx"
 args = ["delta-exchange-mcp"]
 env = { DELTA_MCP_ENV = "india_prod", DELTA_API_KEY = "your-api-key", DELTA_API_SECRET = "your-api-secret" }
 ```
+
+### Codex desktop app
+
+To add the server from the app's UI, go to **Plugins → MCPs → Connect to a custom MCP**, leave **Type** as STDIO, and fill in:
+
+| Field | Value |
+|---|---|
+| Name | `delta-exchange-mcp` |
+| Command to launch | `uvx` (`uvx.exe` on Windows) |
+| Arguments | `delta-exchange-mcp` |
+| Environment variables | `DELTA_MCP_ENV` = `india_prod`, `DELTA_API_KEY` = your-api-key, `DELTA_API_SECRET` = your-api-secret |
+
+Leave the other fields empty, then restart the app.
 
 ### Windsurf
 

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -3,32 +3,42 @@
 #
 # Two modes:
 #
-#   Web UI mode (default) — opens UI on :6274 and proxy on :6277.
+#   Web UI mode (default) - opens UI on :6274 and proxy on :6277.
 #     bash scripts/inspect.sh
 #   With creds:
 #     DELTA_API_KEY=... DELTA_API_SECRET=... bash scripts/inspect.sh
 #
-#   CLI mode — headless, works over SSH (no browser needed).
+#   CLI mode - headless, works over SSH (no browser needed).
 #     bash scripts/inspect.sh --cli --method tools/list
 #     bash scripts/inspect.sh --cli --method tools/call \
 #       --tool-name get_ticker --tool-arg symbol=BTCUSD
 #
-# Note: the Inspector treats everything before its own flags as the server
-# command. So the correct invocation is:
-#   npx ... inspector [-e KEY=VAL ...] <server-cmd> [<server-args>...] [--method ...] [--cli]
+# Inspector v2 wants the mode flag first and the server command before every option,
+# so the layout is:
+#   inspector <mode> <server-cmd> [<server-args>...] [-e KEY=VAL ...] [--method ...]
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
 export PATH="$HOME/.local/bin:$PATH"
 
-# Bind to 0.0.0.0 so Tailscale clients can open the UI. Comment this out if
-# you'd rather SSH port-forward (ssh -L 6274:localhost:6274 <host>).
-export HOST="${HOST:-0.0.0.0}"
+# v1 took the mode flag last. v2 forwards a trailing --cli to the server, so the web UI
+# opened instead of the CLI and the server exited 2 on the unknown flag.
+MODE="--web"
+case "${1:-}" in
+  --cli|--tui|--web)
+    MODE="$1"
+    shift
+    ;;
+esac
+
+# The Inspector refuses to bind 0.0.0.0: its backend spawns local processes, which is what
+# DNS-rebinding attacks target. For remote access: ssh -L 6274:localhost:6274 <host>
+export HOST="${HOST:-127.0.0.1}"
 export CLIENT_PORT="${CLIENT_PORT:-6274}"
 export SERVER_PORT="${SERVER_PORT:-6277}"
 
 ENV_ARGS=(
-  -e "DELTA_MCP_ENV=${DELTA_MCP_ENV:-testnet}"
+  -e "DELTA_MCP_ENV=${DELTA_MCP_ENV:-india_testnet}"
   -e "DELTA_MCP_MODE=${DELTA_MCP_MODE:-read}"
 )
 if [[ -n "${DELTA_API_KEY:-}" ]]; then
@@ -39,6 +49,7 @@ if [[ -n "${DELTA_API_SECRET:-}" ]]; then
 fi
 
 exec npx --yes @modelcontextprotocol/inspector \
-  "${ENV_ARGS[@]}" \
+  "$MODE" \
   uv run delta-exchange-mcp \
+  "${ENV_ARGS[@]}" \
   "$@"


### PR DESCRIPTION
Promotes docs and dev-script changes landed on `develop` after the v0.4.2 cut. No source or test changes, so there is nothing here that reaches the published package.

## Added

- README section with a copyable prompt that lets a coding agent do the install. It writes placeholder credentials only and verifies with `uvx delta-exchange-mcp --version`. #35
- README section for the Codex desktop app UI form, and the existing Codex section renamed to "Codex CLI". #32

## Fixed

- `scripts/inspect.sh` works with MCP Inspector v2 again. The mode flag now comes first, the server command comes before the `-e` pairs, `HOST` defaults to loopback because v2 refuses to bind `0.0.0.0`, and `DELTA_MCP_ENV` defaults to the valid `india_testnet` instead of `testnet`. The script's interface is unchanged, so every call site in the docs keeps working. #36

## No release

`version` stays at `0.4.2`. `scripts/` is not packaged, so the published wheel is unaffected.

One thing to know: the PyPI project page renders `README.md` from the published distribution, so these README additions will not appear there until a version is next cut. The GitHub README updates immediately, which is what the new agent prompt reads (it fetches the raw README from `main`, so this merge is what makes that prompt self-consistent).

## Verification

`scripts/inspect.sh` was checked against the real server before #36 merged:

```
bash scripts/inspect.sh --cli --method tools/list          -> tools: 14
... --tool-name get_ticker --tool-arg symbol=BTCUSD        -> isError: False, spot 64827.2
web mode                                                   -> client :6274 200, proxy :6277 404
```

Python suite unchanged at `112 passed`, ruff clean.
