### PR TITLE
docs(readme): add codex mcp add as the primary Codex CLI install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,15 @@ Restart Cursor or open **Settings → Tools & MCP** to refresh.
 
 ### Codex CLI
 
-Add to `~/.codex/config.toml`:
+```bash
+codex mcp add delta-exchange-mcp \
+  --env DELTA_MCP_ENV=india_prod \
+  --env DELTA_API_KEY=your-api-key \
+  --env DELTA_API_SECRET=your-api-secret \
+  -- uvx delta-exchange-mcp
+```
+
+Verify with `codex mcp list`. Or write `~/.codex/config.toml` by hand:
 
 ```toml
 [mcp_servers.delta-exchange-mcp]


### PR DESCRIPTION
Codex has a one-command install (`codex mcp add`) equivalent to the `claude mcp add` line we already document for Claude Code, but the README only showed hand-editing `~/.codex/config.toml`. Hand-editing TOML is the harder path and the easier one to get wrong.

Adds the command as the primary route and keeps the manual TOML as the alternative, matching how the Claude Code section reads.

Verified against `codex-cli 0.144.4` on macOS, using a sandboxed `CODEX_HOME` so no real config was touched:

```
$ codex mcp add delta-exchange-mcp --env DELTA_MCP_ENV=india_prod ... -- uvx delta-exchange-mcp
Added global MCP server 'delta-exchange-mcp'.
```

It writes exactly the TOML block already in the README. `codex mcp list` then shows the server with env values masked.

Docs only — no code paths touched.