### PR TITLE
feat(config): one shared settings file so an API key is set once, not per client

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ The form has four fields:
 
 - **Environment** — which exchange to talk to: `india_prod` for the real one, or
   `india_testnet` for the practice site at demo.delta.exchange.
-- **API key** and **API secret** — leave both empty for market data only. Fill them in to let
-  the assistant read your own account. Create them under
-  [Account → API Keys](https://www.delta.exchange/app/account/manageapikeys) with the **Read
-  Data** permission, which is the one that allows viewing but not trading.
+- **API key** and **API secret** — fill them in to let the assistant read your own account.
+  Create them under [Account → API Keys](https://www.delta.exchange/app/account/manageapikeys)
+  with the **Read Data** permission, which is the one that allows viewing but not trading.
+  Leaving them empty gives you market data only, unless you have already put a key in the
+  [shared file](#add-your-api-key), in which case that one is used.
 - **Mode** — defaults to `read`, which cannot place, change or cancel orders. Setting it to
   `trade` adds the tools that do.
 
@@ -63,12 +64,7 @@ Open **Settings → Developer → Edit config**, or edit directly at:
   "mcpServers": {
     "delta-exchange-mcp": {
       "command": "uvx",
-      "args": ["delta-exchange-mcp"],
-      "env": {
-        "DELTA_MCP_ENV": "india_prod",
-        "DELTA_API_KEY": "your-api-key",
-        "DELTA_API_SECRET": "your-api-secret"
-      }
+      "args": ["delta-exchange-mcp"]
     }
   }
 }
@@ -88,8 +84,9 @@ uvx delta-exchange-mcp --help
 ```
 
 The server runs **local stdio only**: your MCP client launches it as a subprocess, and your
-API keys never leave your machine. `uvx` resolves the latest published version from PyPI on
-each launch. To pin a specific version, use `uvx "delta-exchange-mcp==0.4.2"`. Pin `0.4.2`
+API keys never leave your machine — they live in one file that every client reads, not in
+each client's config. See [Add your API key](#add-your-api-key). `uvx` resolves the latest
+published version from PyPI on each launch. To pin a specific version, use `uvx "delta-exchange-mcp==0.4.2"`. Pin `0.4.2`
 or newer: earlier versions do not start on a fresh install (see
 [Troubleshooting](#troubleshooting)).
 
@@ -118,14 +115,14 @@ exchange, verbatim from a Claude Desktop session against the live API:
 
 ## Capabilities
 
-What the server can do is decided entirely by environment flags — three tiers, each a strict
-superset of the one above it:
+What the server can do is decided entirely by settings — three tiers, each a strict superset
+of the one above it:
 
 | Tier | You set | Unlocks | Audit-logged |
 |---|---|---|---|
 | Market data | nothing | Prices, order books, option chains, candles, funding / OI history, indices | — |
-| Account, read-only | `DELTA_API_KEY` + `DELTA_API_SECRET` | Your positions, orders, fills, balances, trading stats, profile | — |
-| Trading | both keys + `DELTA_MCP_MODE=trade` | Place / edit / cancel orders, brackets, leverage, margin, close-all | Yes |
+| Account, read-only | an API key — see [Add your API key](#add-your-api-key) | Your positions, orders, fills, balances, trading stats, profile | — |
+| Trading | a key plus `DELTA_MCP_MODE=trade` in one client's config | Place / edit / cancel orders, brackets, leverage, margin, close-all | Yes |
 
 A key without its matching secret is ignored and you stay on market data — the two are
 always used together.
@@ -141,20 +138,20 @@ them.
 > sending, convert between contracts and coins, or judge whether an order makes sense. Those
 > are your responsibility. Try `DELTA_MCP_ENV=india_testnet` first.
 
-Enable it in your client config:
+Enable it in the config of the one client you mean to trade from:
 
 ```jsonc
 "delta-exchange-mcp": {
   "command": "uvx",
   "args": ["delta-exchange-mcp"],
-  "env": {
-    "DELTA_MCP_ENV": "india_prod",
-    "DELTA_API_KEY": "your-api-key",
-    "DELTA_API_SECRET": "your-api-secret",
-    "DELTA_MCP_MODE": "trade"
-  }
+  "env": { "DELTA_MCP_MODE": "trade" }
 }
 ```
+
+This is the only setting that cannot come from the shared file described in
+[Add your API key](#add-your-api-key). Everything else there is convenience; this one
+places real orders, so it stays scoped to the single client whose config you edited
+rather than arming every assistant on the machine at once.
 
 Safety features:
 
@@ -163,30 +160,86 @@ Safety features:
 - **No silent retries.** Unlike GET reads, mutations are never auto-retried on timeout or rate-limit — a failure is surfaced, not re-sent.
 - **API key permission.** The key must have Trading enabled in Delta API management, and the requesting IP whitelisted.
 
-### Environment variables
+## Add your API key
 
-| Var | Default | Purpose |
-|---|---|---|
-| `DELTA_MCP_ENV` | `india_prod` | `india_prod`, `india_testnet`, or `india_devnet`. |
-| `DELTA_API_KEY` | _(unset)_ | API key. Optional; when set with `DELTA_API_SECRET`, account tools register. |
-| `DELTA_API_SECRET` | _(unset)_ | API secret matching `DELTA_API_KEY`. |
-| `DELTA_MCP_MODE` | `read` | `trade` registers the trading tools (requires API key + secret). Default `read` is read-only. See [Trading](#trading-opt-in). |
-| `DELTA_MCP_DEBUG` | _(unset)_ | `1`/`true`/`yes`/`on` writes HTTP request URLs and response bodies to a log file (see [Debugging](#debugging--reporting-a-bug)). |
-| `DELTA_MCP_DEBUG_FILE` | _(auto)_ | Override the debug log path. Default: `~/.delta-exchange-mcp/logs/debug-<timestamp>-<pid>.log`. |
-| `DELTA_MCP_AUDIT` | _(on in trade mode)_ | Set `off`/`false`/`0`/`no` to disable the trading audit log. On by default whenever `DELTA_MCP_MODE=trade`. |
-| `DELTA_MCP_AUDIT_FILE` | _(auto)_ | Override the audit log path. Default: `~/.delta-exchange-mcp/audit/audit-<timestamp>-<pid>.log`. |
+**You may not need one.** Market data works with no key at all, so if you only want prices,
+option chains or funding history, skip this section entirely.
 
-### Getting an API key
+To let an assistant read your own account, the key goes in **one file, once** — not into
+each client's config:
 
-1. Create a key at [delta.exchange/app/account/manageapikeys](https://www.delta.exchange/app/account/manageapikeys) (testnet: [demo.delta.exchange](https://demo.delta.exchange/app/account/manageapikeys)).
+```
+~/.delta-exchange-mcp/config.env
+```
+
+Every MCP client on your machine reads it, so a key set here works in Claude Desktop,
+Cursor, Claude Code and everything else at the same time. The server creates the file the
+first time it runs, with instructions inside it, and prints the path in its startup line.
+It is created owner-only (`0600`).
+
+Two ways to fill it in.
+
+**At a terminal**, which prompts with the input hidden and checks the key works before
+saving anything:
+
+```bash
+uvx delta-exchange-mcp login
+```
+
+**By hand**, if you'd rather. Open the file and fill in the three lines already waiting
+there — plain `NAME=value`, no punctuation to get wrong:
+
+```dotenv
+DELTA_API_KEY=your-key-here
+DELTA_API_SECRET=your-secret-here
+DELTA_MCP_ENV=india_prod
+```
+
+Restart your MCP client afterwards. If your client has its own place to put credentials —
+the Claude Desktop bundle's form, VS Code's prompts, the Codex desktop app's fields — those
+still work and take precedence over this file.
+
+### Getting the key itself
+
+1. Create it at [delta.exchange/app/account/manageapikeys](https://www.delta.exchange/app/account/manageapikeys) (testnet: [demo.delta.exchange](https://demo.delta.exchange/app/account/manageapikeys)).
 2. Both `api_key` and `api_secret` are shown **once at creation**. Save the secret immediately; it can't be re-derived.
 3. **Read Data** permission is enough for the read tiers. Trading permission is needed only for trade mode.
 4. Recommended: whitelist your IP on the key. Delta blocks non-whitelisted IPs and surfaces your current IP in the error message if it fires.
-5. **Match the environment**: prod keys with `DELTA_MCP_ENV=india_prod`, demo keys with `DELTA_MCP_ENV=india_testnet`. Mixing them returns `InvalidApiKey`.
+5. **Match the environment**: a key from delta.exchange works only with `india_prod`, one from demo.delta.exchange only with `india_testnet`. Mixing them returns `InvalidApiKey`.
+
+`login` checks all four of these for you and refuses to save a key that fails, so you find
+out while you still have the key in front of you rather than the next time you ask a
+question.
+
+### Settings reference
+
+Each setting is read from your MCP client first, then from `~/.delta-exchange-mcp/config.env`.
+A value your client sets always wins; leaving it empty there means "not answered" and falls
+through to the file.
+
+| Var | Default | Shared file? | Purpose |
+|---|---|---|---|
+| `DELTA_MCP_ENV` | `india_prod` | yes | `india_prod`, `india_testnet`, or `india_devnet`. |
+| `DELTA_API_KEY` | _(unset)_ | yes | API key. Optional; when set with `DELTA_API_SECRET`, account tools register. |
+| `DELTA_API_SECRET` | _(unset)_ | yes | API secret matching `DELTA_API_KEY`. |
+| `DELTA_MCP_MODE` | `read` | **no** | `trade` registers the trading tools (requires API key + secret). Per client on purpose — see [Trading](#trading-opt-in). |
+| `DELTA_MCP_DEBUG` | _(unset)_ | yes | `1`/`true`/`yes`/`on` writes HTTP request URLs and response bodies to a log file (see [Debugging](#debugging--reporting-a-bug)). |
+| `DELTA_MCP_DEBUG_FILE` | _(auto)_ | yes | Override the debug log path. Default: `~/.delta-exchange-mcp/logs/debug-<timestamp>-<pid>.log`. |
+| `DELTA_MCP_AUDIT` | _(on in trade mode)_ | yes | Set `off`/`false`/`0`/`no` to disable the trading audit log. On by default whenever `DELTA_MCP_MODE=trade`. |
+| `DELTA_MCP_AUDIT_FILE` | _(auto)_ | yes | Override the audit log path. Default: `~/.delta-exchange-mcp/audit/audit-<timestamp>-<pid>.log`. |
+| `DELTA_MCP_CONFIG_FILE` | _(auto)_ | n/a | Move the shared file itself. Default: `~/.delta-exchange-mcp/config.env`. |
+
+The key and its secret are always taken from the same place. If either is set in your
+client, both come from there; otherwise both come from the file. That prevents pairing a
+stale key from your shell with a secret from the file — a combination that was never issued
+together, and which fails every signed call while the server reports the account tools as
+available.
 
 ## Install in your MCP client
 
-`DELTA_API_KEY` / `DELTA_API_SECRET` are **optional** in every snippet below — drop them for public-data-only mode. Set `DELTA_MCP_ENV=india_testnet` for testnet.
+None of the snippets below carry credentials, because they don't need to — put the key in
+[the shared file](#add-your-api-key) once instead. Set `DELTA_MCP_ENV=india_testnet` there
+for testnet.
 
 ### Let your coding agent set it up
 
@@ -194,18 +247,18 @@ Copy this into Claude Code, Codex, Cursor, or any agent that can edit files on y
 
 ```text
 Install the Delta Exchange MCP server into my MCP client: uvx delta-exchange-mcp, local
-stdio, entry name delta-exchange-mcp. Leave my other servers alone and write no API keys.
-Verify with `uvx delta-exchange-mcp --version` — never run it bare, it serves stdio and
-won't exit. Tell me what to restart.
+stdio, entry name delta-exchange-mcp, no env block. Leave my other servers alone, and
+never ask me for my API key. Verify with `uvx delta-exchange-mcp --version` — never run
+it bare, it serves stdio and won't exit. Tell me what to restart.
 
 If you don't know where my client keeps its MCP config, read
 https://raw.githubusercontent.com/delta-exchange/delta-exchange-mcp/main/README.md
 ```
 
-It writes no credentials on purpose, so the server comes up serving market data and works
-the moment you restart. Add `DELTA_API_KEY` and `DELTA_API_SECRET` to the entry it created
-when you want your own account. To set it up by hand instead, follow the steps for your
-client below.
+The entry it writes holds no credentials and needs none — the server comes up on market
+data and works the moment you restart. Your key goes in
+[the shared file](#add-your-api-key) instead, which is why the agent never has to touch it.
+To set it up by hand, follow the steps for your client below.
 
 ### Cursor
 
@@ -223,12 +276,7 @@ Global: `~/.cursor/mcp.json` (or `%USERPROFILE%\.cursor\mcp.json` on Windows). P
   "mcpServers": {
     "delta-exchange-mcp": {
       "command": "uvx",
-      "args": ["delta-exchange-mcp"],
-      "env": {
-        "DELTA_MCP_ENV": "india_prod",
-        "DELTA_API_KEY": "your-api-key",
-        "DELTA_API_SECRET": "your-api-secret"
-      }
+      "args": ["delta-exchange-mcp"]
     }
   }
 }
@@ -279,12 +327,7 @@ Add to `.vscode/mcp.json` in your workspace. The top-level key is `servers` and 
     "delta-exchange-mcp": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["delta-exchange-mcp"],
-      "env": {
-        "DELTA_MCP_ENV": "${input:delta-env}",
-        "DELTA_API_KEY": "${input:delta-api-key}",
-        "DELTA_API_SECRET": "${input:delta-api-secret}"
-      }
+      "args": ["delta-exchange-mcp"]
     }
   }
 }
@@ -298,11 +341,7 @@ Leave both prompts empty for public-data-only mode.
 
 ```bash
 claude mcp add delta-exchange-mcp \
-  --scope user \
-  --env DELTA_MCP_ENV=india_prod \
-  --env DELTA_API_KEY=your-api-key \
-  --env DELTA_API_SECRET=your-api-secret \
-  -- uvx delta-exchange-mcp
+  --scope user -- uvx delta-exchange-mcp
 ```
 
 `--scope user` makes the server available across all projects. Verify with `claude mcp list`.
@@ -310,11 +349,7 @@ claude mcp add delta-exchange-mcp \
 ### Codex
 
 ```bash
-codex mcp add delta-exchange-mcp \
-  --env DELTA_MCP_ENV=india_prod \
-  --env DELTA_API_KEY=your-api-key \
-  --env DELTA_API_SECRET=your-api-secret \
-  -- uvx delta-exchange-mcp
+codex mcp add delta-exchange-mcp -- uvx delta-exchange-mcp
 ```
 
 Verify with `codex mcp list`.
@@ -324,14 +359,11 @@ Verify with `codex mcp list`.
 ```bash
 openclaw mcp add delta-exchange-mcp \
   --command uvx \
-  --arg delta-exchange-mcp \
-  --env DELTA_MCP_ENV=india_prod \
-  --env DELTA_API_KEY=your-api-key \
-  --env DELTA_API_SECRET=your-api-secret
+  --arg delta-exchange-mcp
 ```
 
-Repeat `--arg` and `--env` once per value. Writes to `~/.openclaw/openclaw.json`, where MCP
-servers live under `mcp.servers` rather than a top-level `mcpServers` key.
+Repeat `--arg` once per value. Writes to `~/.openclaw/openclaw.json`, where MCP servers live
+under `mcp.servers` rather than a top-level `mcpServers` key.
 
 <details>
 <summary><b>Codex — TOML config, or the desktop app's form</b></summary>
@@ -342,7 +374,6 @@ Write `~/.codex/config.toml` by hand:
 [mcp_servers.delta-exchange-mcp]
 command = "uvx"
 args = ["delta-exchange-mcp"]
-env = { DELTA_MCP_ENV = "india_prod", DELTA_API_KEY = "your-api-key", DELTA_API_SECRET = "your-api-secret" }
 ```
 
 Desktop app: go to **Plugins → MCPs → Connect to a custom MCP**, leave **Type** as STDIO, and fill in:
@@ -352,7 +383,7 @@ Desktop app: go to **Plugins → MCPs → Connect to a custom MCP**, leave **Typ
 | Name | `delta-exchange-mcp` |
 | Command to launch | `uvx` (`uvx.exe` on Windows) |
 | Arguments | `delta-exchange-mcp` |
-| Environment variables | `DELTA_MCP_ENV` = `india_prod`, `DELTA_API_KEY` = your-api-key, `DELTA_API_SECRET` = your-api-secret |
+| Environment variables | leave empty |
 
 Leave the other fields empty, then restart the app.
 
@@ -370,12 +401,7 @@ Add to `~/.codeium/windsurf/mcp_config.json` (macOS / Linux) or `%USERPROFILE%\.
   "mcpServers": {
     "delta-exchange-mcp": {
       "command": "uvx",
-      "args": ["delta-exchange-mcp"],
-      "env": {
-        "DELTA_MCP_ENV": "india_prod",
-        "DELTA_API_KEY": "your-api-key",
-        "DELTA_API_SECRET": "your-api-secret"
-      }
+      "args": ["delta-exchange-mcp"]
     }
   }
 }
@@ -397,12 +423,7 @@ usual shape:
   "context_servers": {
     "delta-exchange-mcp": {
       "command": "uvx",
-      "args": ["delta-exchange-mcp"],
-      "env": {
-        "DELTA_MCP_ENV": "india_prod",
-        "DELTA_API_KEY": "your-api-key",
-        "DELTA_API_SECRET": "your-api-secret"
-      }
+      "args": ["delta-exchange-mcp"]
     }
   }
 }
@@ -425,12 +446,7 @@ Servers → View raw config**. In the CLI, type `/mcp`.
   "mcpServers": {
     "delta-exchange-mcp": {
       "command": "uvx",
-      "args": ["delta-exchange-mcp"],
-      "env": {
-        "DELTA_MCP_ENV": "india_prod",
-        "DELTA_API_KEY": "your-api-key",
-        "DELTA_API_SECRET": "your-api-secret"
-      }
+      "args": ["delta-exchange-mcp"]
     }
   }
 }
@@ -506,11 +522,7 @@ something unexpected — set `DELTA_MCP_DEBUG=1` in your MCP client config:
 ```jsonc
 "delta-exchange-mcp": {
   "command": "uvx",
-  "args": ["delta-exchange-mcp"],
-  "env": {
-    "DELTA_MCP_ENV": "india_prod",
-    "DELTA_MCP_DEBUG": "1"
-  }
+  "args": ["delta-exchange-mcp"]
 }
 ```
 
@@ -545,8 +557,7 @@ Replace `args` in any snippet above with the `git+` form. Three flavours:
 
 ```bash
 claude mcp add delta-exchange-mcp-dev \
-  --scope user \
-  --env DELTA_MCP_ENV=india_prod \
+  --scope user
   -- uvx --from git+https://github.com/delta-exchange/delta-exchange-mcp.git@develop delta-exchange-mcp
 ```
 
@@ -561,10 +572,7 @@ claude mcp add delta-exchange-mcp-dev \
         "--from",
         "git+https://github.com/delta-exchange/delta-exchange-mcp.git@develop",
         "delta-exchange-mcp"
-      ],
-      "env": {
-        "DELTA_MCP_ENV": "india_prod"
-      }
+      ]
     }
   }
 }
@@ -581,10 +589,7 @@ claude mcp add delta-exchange-mcp-dev \
         "--from",
         "git+https://github.com/delta-exchange/delta-exchange-mcp.git@develop",
         "delta-exchange-mcp"
-      ],
-      "env": {
-        "DELTA_MCP_ENV": "india_prod"
-      }
+      ]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -524,9 +524,13 @@ something unexpected — set `DELTA_MCP_DEBUG=1` in your MCP client config:
 ```jsonc
 "delta-exchange-mcp": {
   "command": "uvx",
-  "args": ["delta-exchange-mcp"]
+  "args": ["delta-exchange-mcp"],
+  "env": { "DELTA_MCP_DEBUG": "1" }
 }
 ```
+
+Or set it once for every client by adding `DELTA_MCP_DEBUG=1` to
+[the shared file](#add-your-api-key).
 
 Restart the client and re-run the action. Each HTTP call (request URL incl. filter params +
 response body + status) is logged to `~/.delta-exchange-mcp/logs/`. The exact path is printed
@@ -559,7 +563,7 @@ Replace `args` in any snippet above with the `git+` form. Three flavours:
 
 ```bash
 claude mcp add delta-exchange-mcp-dev \
-  --scope user
+  --scope user \
   -- uvx --from git+https://github.com/delta-exchange/delta-exchange-mcp.git@develop delta-exchange-mcp
 ```
 

--- a/packaging/mcpb/README.md
+++ b/packaging/mcpb/README.md
@@ -90,6 +90,19 @@ start.
 
 ## Decisions
 
+**An empty form field falls through to the shared settings file.** The server reads
+`~/.delta-exchange-mcp/config.env` for anything its environment does not answer, and a
+bundle substitutes every variable it declares whether or not the user filled that field —
+so a blank API-key box arrives as `""`. Empty therefore has to mean "unanswered" rather
+than "answered with nothing", or the shared file could never reach a bundle user at all.
+Someone who has already run `delta-exchange-mcp login` can accept the whole form and still
+get their account.
+
+`verify.py` redirects that file into its throwaway unpack directory. Without it the
+verifier would read the developer's own copy, and a `DELTA_MCP_DEBUG=1` there would
+register a debug tool the manifest does not declare — failing the undeclared-tool check
+locally while passing in CI. It also keeps a build from writing into `$HOME`.
+
 **Trading is present but opt-in.** `DELTA_MCP_MODE` is a `user_config` field defaulting to
 `read`, substituted into the launch environment as `${user_config.mode}`. Someone who accepts
 the form gets 27 tools and no mutations; someone who types `trade` gets 41 and can place real

--- a/packaging/mcpb/make_bundle.py
+++ b/packaging/mcpb/make_bundle.py
@@ -12,6 +12,7 @@ import json
 import os
 import pathlib
 import sys
+import tempfile
 import tomllib
 
 HERE = pathlib.Path(__file__).resolve().parent
@@ -131,6 +132,12 @@ async def tool_entries() -> list[dict[str, str]]:
     os.environ["DELTA_MCP_MODE"] = "trade"
     os.environ["DELTA_API_KEY"] = "placeholder"
     os.environ["DELTA_API_SECRET"] = "placeholder"
+    # The shared settings file is redirected as well, or the build reads the developer's
+    # own. Measured: a DELTA_MCP_DEBUG=1 line in ~/.delta-exchange-mcp/config.env writes
+    # get_debug_status into the manifest — 42 tools instead of 41 — and CI, which has no
+    # such file, then rejects that manifest as stale. It also stops a build creating a file
+    # in a home directory it has no business touching.
+    os.environ["DELTA_MCP_CONFIG_FILE"] = str(pathlib.Path(tempfile.mkdtemp()) / "config.env")
     from delta_exchange_mcp.server import build_server
 
     tools = await build_server().list_tools()

--- a/packaging/mcpb/verify.py
+++ b/packaging/mcpb/verify.py
@@ -75,7 +75,7 @@ def check_archive(mcpb: Path) -> None:
     print(f"  payload: {', '.join(sorted(required))}, {wheels.pop()}")
 
 
-def launch_env(manifest: dict, mode: str) -> dict[str, str]:
+def launch_env(manifest: dict, mode: str, config_file: Path) -> dict[str, str]:
     """The environment a host would build, over a deliberately hostile one.
 
     The ambient half sets DELTA_MCP_MODE=trade and supplies credentials, which is what a
@@ -83,6 +83,13 @@ def launch_env(manifest: dict, mode: str) -> dict[str, str]:
     ${user_config.x} resolved the way the host resolves it. Checking the result is what
     makes "the form decides the mode, not the environment" an actual test rather than an
     assertion that passes because no credentials were present.
+
+    The shared settings file is redirected into the throwaway unpack directory. The
+    server reads ~/.delta-exchange-mcp/config.env for anything the manifest does not
+    declare, and the manifest declares only mode, environment and the two credentials —
+    so a developer with DELTA_MCP_DEBUG=1 in their own file would register a debug tool
+    that is not in the manifest and fail the undeclared-tool check here but not in CI.
+    Redirecting also keeps a build from writing into the user's home directory.
     """
     config = {k: v.get("default", "") for k, v in manifest["user_config"].items()}
     config.update({"mode": mode, "api_key": "placeholder", "api_secret": "placeholder"})
@@ -92,6 +99,7 @@ def launch_env(manifest: dict, mode: str) -> dict[str, str]:
         "DELTA_MCP_MODE": "trade",
         "DELTA_API_KEY": "ambient",
         "DELTA_API_SECRET": "ambient",
+        "DELTA_MCP_CONFIG_FILE": str(config_file),
     })
     for key, raw in manifest["server"]["mcp_config"]["env"].items():
         env[key] = re.sub(
@@ -181,7 +189,10 @@ def main() -> None:
 
         # Someone who accepted the form's defaults, on a machine whose environment is
         # already asking for trade mode. The declared default has to win.
-        default = handshake(tmp, launch_env(manifest, manifest["user_config"]["mode"]["default"]))
+        shared = tmp / "shared-config.env"
+        default = handshake(
+            tmp, launch_env(manifest, manifest["user_config"]["mode"]["default"], shared)
+        )
         leaked = [n for n in default if n.startswith(MUTATION_PREFIXES)]
         print(f"  default mode: {len(default)} tools, {len(leaked)} mutating")
         if leaked:
@@ -193,7 +204,7 @@ def main() -> None:
             raise SystemExit("no tools registered")
 
         # And the opt-in has to actually reach trading, or the field is decorative.
-        opted = handshake(tmp, launch_env(manifest, "trade"))
+        opted = handshake(tmp, launch_env(manifest, "trade", shared))
         mutating = [n for n in opted if n.startswith(MUTATION_PREFIXES)]
         print(f"  mode=trade:   {len(opted)} tools, {len(mutating)} mutating")
         if not mutating:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ dependencies = [
     "httpx>=0.28.1,<1",
     "mcp>=1.12.4,<2",
     "pydantic>=2.13.2,<3",
+    # Already resolved via mcp -> pydantic-settings, but declared because we import it
+    # directly. Hand-rolling the parse is what it replaces: quoted values, an `export`
+    # prefix, a trailing comment or CRLF endings each corrupt a credential silently.
+    "python-dotenv>=1.0,<2",
 ]
 
 [project.urls]

--- a/src/delta_exchange_mcp/audit_log.py
+++ b/src/delta_exchange_mcp/audit_log.py
@@ -20,11 +20,11 @@ import time
 from pathlib import Path
 from typing import Any
 
-from delta_exchange_mcp.config import Config
+from delta_exchange_mcp.config import Config, setting
 
 
 def _resolve_path() -> Path:
-    override = os.environ.get("DELTA_MCP_AUDIT_FILE")
+    override = setting("DELTA_MCP_AUDIT_FILE")
     if override:
         return Path(override).expanduser()
     stamp = time.strftime("%Y%m%d-%H%M%S")
@@ -92,7 +92,7 @@ def configure(cfg: Config) -> AuditLog | None:
     global _INSTANCE
     if cfg.mode != "trade":
         return None
-    if os.environ.get("DELTA_MCP_AUDIT", "").strip().lower() in _DISABLE:
+    if (setting("DELTA_MCP_AUDIT") or "").lower() in _DISABLE:
         return None
     if _INSTANCE is not None:
         return _INSTANCE

--- a/src/delta_exchange_mcp/config.py
+++ b/src/delta_exchange_mcp/config.py
@@ -53,21 +53,23 @@ class Config:
         return bool(self.api_key) != bool(self.api_secret)
 
 
-def setting(name: str) -> str | None:
+def setting(name: str, shared: dict[str, str] | None = None) -> str | None:
     """Resolve one setting: the process environment first, then the shared file.
 
     Empty means unanswered rather than answered-with-nothing. A bundle substitutes
     every variable it declares whether or not the user filled that field in, so a
     cleared input arrives as "" — it has to fall through to the file rather than
-    override it, or the shared file could never reach a bundle user at all.
+    override it, or the shared file could never reach a bundle user at all. `shared`
+    lets one caller resolve several settings from the same file snapshot.
     """
     from_env = (os.environ.get(name) or "").strip()
     if from_env:
         return from_env
-    return (store.read().get(name) or "").strip() or None
+    values = store.read() if shared is None else shared
+    return (values.get(name) or "").strip() or None
 
 
-def _credentials() -> tuple[str | None, str | None]:
+def _credentials(shared: dict[str, str]) -> tuple[str | None, str | None]:
     """The API key and its secret, always taken from the same source.
 
     Resolving them independently could pair a leftover DELTA_API_KEY in someone's
@@ -84,7 +86,6 @@ def _credentials() -> tuple[str | None, str | None]:
     secret = (os.environ.get("DELTA_API_SECRET") or "").strip() or None
     if key or secret:
         return key, secret
-    shared = store.read()
     return (
         (shared.get("DELTA_API_KEY") or "").strip() or None,
         (shared.get("DELTA_API_SECRET") or "").strip() or None,
@@ -93,8 +94,11 @@ def _credentials() -> tuple[str | None, str | None]:
 
 def load() -> Config:
     config_file = store.ensure()
+    # `store.write` replaces a complete file atomically. Read it once so one Config
+    # cannot combine the environment from the old file with credentials from the new.
+    shared = store.read()
 
-    env = (setting("DELTA_MCP_ENV") or DEFAULT_ENV).lower()
+    env = (setting("DELTA_MCP_ENV", shared) or DEFAULT_ENV).lower()
     if env not in BASE_URLS:
         raise ValueError(
             f"DELTA_MCP_ENV must be one of {sorted(BASE_URLS)}, got {env!r}"
@@ -107,14 +111,14 @@ def load() -> Config:
     if mode not in MODES:
         raise ValueError(f"DELTA_MCP_MODE must be one of {sorted(MODES)}, got {mode!r}")
 
-    api_key, api_secret = _credentials()
+    api_key, api_secret = _credentials(shared)
 
     return Config(
         env=env,  # type: ignore[arg-type]
         base_url=BASE_URLS[env],
         api_key=api_key,
         api_secret=api_secret,
-        debug=(setting("DELTA_MCP_DEBUG") or "").lower() in TRUTHY,
+        debug=(setting("DELTA_MCP_DEBUG", shared) or "").lower() in TRUTHY,
         mode=mode,  # type: ignore[arg-type]
         config_file=config_file,
     )

--- a/src/delta_exchange_mcp/config.py
+++ b/src/delta_exchange_mcp/config.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
+
+from delta_exchange_mcp import store
 
 Env = Literal["india_prod", "india_testnet", "india_devnet"]
 Mode = Literal["read", "trade"]
@@ -33,6 +36,7 @@ class Config:
     api_secret: str | None = None
     debug: bool = False
     mode: Mode = "read"
+    config_file: Path | None = None
 
     @property
     def has_credentials(self) -> bool:
@@ -49,25 +53,68 @@ class Config:
         return bool(self.api_key) != bool(self.api_secret)
 
 
+def setting(name: str) -> str | None:
+    """Resolve one setting: the process environment first, then the shared file.
+
+    Empty means unanswered rather than answered-with-nothing. A bundle substitutes
+    every variable it declares whether or not the user filled that field in, so a
+    cleared input arrives as "" — it has to fall through to the file rather than
+    override it, or the shared file could never reach a bundle user at all.
+    """
+    from_env = (os.environ.get(name) or "").strip()
+    if from_env:
+        return from_env
+    return (store.read().get(name) or "").strip() or None
+
+
+def _credentials() -> tuple[str | None, str | None]:
+    """The API key and its secret, always taken from the same source.
+
+    Resolving them independently could pair a leftover DELTA_API_KEY in someone's
+    shell with a secret from the shared file. That combination was never issued
+    together, so every signed request fails while the server reports the account
+    surface as available — the least diagnosable outcome available. Taking both from
+    wherever either one appears turns that into the partial-credentials warning,
+    which says exactly what is wrong.
+    """
+    # Stripped like every other setting, so a whitespace-only field reads as unanswered
+    # and falls through. Stripping also absorbs the trailing newline a pasted key
+    # usually carries, which would otherwise fail signing and look like a wrong key.
+    key = (os.environ.get("DELTA_API_KEY") or "").strip() or None
+    secret = (os.environ.get("DELTA_API_SECRET") or "").strip() or None
+    if key or secret:
+        return key, secret
+    shared = store.read()
+    return (
+        (shared.get("DELTA_API_KEY") or "").strip() or None,
+        (shared.get("DELTA_API_SECRET") or "").strip() or None,
+    )
+
+
 def load() -> Config:
-    # Empty falls back to the default rather than failing. A bundle substitutes every
-    # declared variable whether or not the user filled the field in, so a cleared input
-    # arrives as "" where a hand-written config would simply omit the variable.
-    env = os.environ.get("DELTA_MCP_ENV", "").strip().lower() or DEFAULT_ENV
+    config_file = store.ensure()
+
+    env = (setting("DELTA_MCP_ENV") or DEFAULT_ENV).lower()
     if env not in BASE_URLS:
         raise ValueError(
             f"DELTA_MCP_ENV must be one of {sorted(BASE_URLS)}, got {env!r}"
         )
 
-    mode = os.environ.get("DELTA_MCP_MODE", "").strip().lower() or DEFAULT_MODE
+    # Mode is the one setting the shared file may not supply. Everything else there is
+    # per-machine convenience; this one places real orders, so it stays scoped to the
+    # single client whose config was deliberately edited to enable it.
+    mode = (os.environ.get("DELTA_MCP_MODE", "") or "").strip().lower() or DEFAULT_MODE
     if mode not in MODES:
         raise ValueError(f"DELTA_MCP_MODE must be one of {sorted(MODES)}, got {mode!r}")
+
+    api_key, api_secret = _credentials()
 
     return Config(
         env=env,  # type: ignore[arg-type]
         base_url=BASE_URLS[env],
-        api_key=os.environ.get("DELTA_API_KEY") or None,
-        api_secret=os.environ.get("DELTA_API_SECRET") or None,
-        debug=os.environ.get("DELTA_MCP_DEBUG", "").strip().lower() in TRUTHY,
+        api_key=api_key,
+        api_secret=api_secret,
+        debug=(setting("DELTA_MCP_DEBUG") or "").lower() in TRUTHY,
         mode=mode,  # type: ignore[arg-type]
+        config_file=config_file,
     )

--- a/src/delta_exchange_mcp/debug_log.py
+++ b/src/delta_exchange_mcp/debug_log.py
@@ -18,7 +18,7 @@ import tempfile
 import time
 from pathlib import Path
 
-from delta_exchange_mcp.config import Config
+from delta_exchange_mcp.config import Config, setting
 from delta_exchange_mcp.version import PACKAGE_VERSION
 
 LOGGER_NAMES = ("delta_exchange_mcp", "httpx")
@@ -28,7 +28,7 @@ _MARKER = "_delta_debug_handler"
 
 
 def _resolve_path() -> Path:
-    override = os.environ.get("DELTA_MCP_DEBUG_FILE")
+    override = setting("DELTA_MCP_DEBUG_FILE")
     if override:
         return Path(override).expanduser()
     stamp = time.strftime("%Y%m%d-%H%M%S")

--- a/src/delta_exchange_mcp/errors.py
+++ b/src/delta_exchange_mcp/errors.py
@@ -35,6 +35,11 @@ _AUTH_HINTS: dict[str, str] = {
     ),
 }
 
+# A response carrying one of these codes proves that the submitted credential pair
+# itself is unusable. Other API failures — especially a rate limit or service outage —
+# only prove that Delta could not verify it at that moment.
+_AUTH_FAILURE_CODES = frozenset(_AUTH_HINTS)
+
 
 def _extract_ip(context: Any) -> str | None:
     if not isinstance(context, dict):
@@ -64,6 +69,11 @@ class DeltaApiError(Exception):
         if status:
             msg += f" [http {status}]"
         super().__init__(msg)
+
+
+def is_auth_failure(error: DeltaApiError) -> bool:
+    """Whether an API error decisively rejects the submitted credentials."""
+    return error.code in _AUTH_FAILURE_CODES
 
 
 class ConfigError(Exception):

--- a/src/delta_exchange_mcp/login.py
+++ b/src/delta_exchange_mcp/login.py
@@ -22,7 +22,7 @@ import httpx
 from delta_exchange_mcp import store
 from delta_exchange_mcp.client import DeltaClient
 from delta_exchange_mcp.config import BASE_URLS, DEFAULT_ENV, Config
-from delta_exchange_mcp.errors import DeltaApiError
+from delta_exchange_mcp.errors import DeltaApiError, is_auth_failure
 
 DASHBOARDS = {
     "india_prod": "https://www.delta.exchange/app/account/manageapikeys",
@@ -51,7 +51,7 @@ async def _check(env: str, key: str, secret: str) -> Check:
     try:
         profile = await client.get("/profile", auth=True)
     except DeltaApiError as exc:
-        return Check(ok=False, reachable=True, detail=str(exc))
+        return Check(ok=False, reachable=is_auth_failure(exc), detail=str(exc))
     except httpx.HTTPError as exc:
         return Check(ok=False, reachable=False, detail=f"could not reach Delta: {exc}")
     else:
@@ -63,9 +63,9 @@ async def _check(env: str, key: str, secret: str) -> Check:
         await client.aclose()
 
 
-def _ask_env() -> str | None:
-    prompt = f"Environment {'/'.join(sorted(BASE_URLS))}\n  [{DEFAULT_ENV}]: "
-    answer = input(prompt).strip().lower() or DEFAULT_ENV
+def _ask_env(default: str = DEFAULT_ENV) -> str | None:
+    prompt = f"Environment {'/'.join(sorted(BASE_URLS))}\n  [{default}]: "
+    answer = input(prompt).strip().lower() or default
     if answer not in BASE_URLS:
         print(f"  not an environment: {answer}", file=sys.stderr)
         return None
@@ -87,28 +87,67 @@ def run(verify: bool = True) -> int:
         print(f"cannot write {store.path()}", file=sys.stderr)
         return 1
 
+    shared = store.read()
+    saved_env_value = (shared.get("DELTA_MCP_ENV") or "").strip().lower()
+    saved_env = saved_env_value if saved_env_value in BASE_URLS else None
+    default_env = saved_env or DEFAULT_ENV
+    saved_key = (shared.get("DELTA_API_KEY") or "").strip()
+    saved_secret = (shared.get("DELTA_API_SECRET") or "").strip()
+    has_saved_pair = bool(saved_key and saved_secret)
+    can_keep_saved = has_saved_pair and saved_env is not None
+
     print(f"Storing credentials in {path}")
-    print("Every MCP client on this machine reads it. Leave blank to keep what is there.\n")
+    print("Every MCP client on this machine reads it.")
+    if can_keep_saved:
+        print("Press Enter to keep the environment and saved credential pair.\n")
+    else:
+        print("Choose an environment and enter both parts of a credential pair.\n")
 
     try:
-        env = _ask_env()
+        env = _ask_env(default_env)
         if env is None:
             return 1
         print(f"  create a key at {DASHBOARDS.get(env, DASHBOARDS[DEFAULT_ENV])}")
         print('  the "Read Data" permission is enough unless you intend to trade\n')
-        key = getpass.getpass("API key (hidden): ").strip()
-        secret = getpass.getpass("API secret (hidden): ").strip()
+        keep = "; Enter keeps saved" if can_keep_saved else ""
+        entered_key = getpass.getpass(f"API key (hidden{keep}): ").strip()
+        entered_secret = getpass.getpass(f"API secret (hidden{keep}): ").strip()
     except (KeyboardInterrupt, EOFError):
         print("\ncancelled, nothing written", file=sys.stderr)
         return 1
 
-    if not key or not secret:
+    if bool(entered_key) != bool(entered_secret):
         print(
-            "both a key and its secret are needed — one without the other leaves the "
-            "server on market data only",
+            "both a key and its secret are needed. Enter both to replace the saved "
+            "pair, or leave both blank to keep it.",
             file=sys.stderr,
         )
         return 1
+
+    if entered_key:
+        key, secret = entered_key, entered_secret
+    elif not has_saved_pair:
+        print(
+            "No complete credential pair is saved. Enter both the API key and secret.",
+            file=sys.stderr,
+        )
+        return 1
+    elif saved_env is None:
+        print(
+            "The saved credential pair has no valid environment. Choose an environment "
+            "and enter a new API key and secret.",
+            file=sys.stderr,
+        )
+        return 1
+    elif env != saved_env:
+        print(
+            f"The saved credentials belong to {saved_env}; changing environments "
+            "requires a new API key and secret.",
+            file=sys.stderr,
+        )
+        return 1
+    else:
+        key, secret = saved_key, saved_secret
 
     if verify:
         print(f"\nChecking against {BASE_URLS[env]} ...")

--- a/src/delta_exchange_mcp/login.py
+++ b/src/delta_exchange_mcp/login.py
@@ -19,8 +19,6 @@ import sys
 from dataclasses import dataclass
 
 import httpx
-from dotenv import set_key
-
 from delta_exchange_mcp import store
 from delta_exchange_mcp.client import DeltaClient
 from delta_exchange_mcp.config import BASE_URLS, DEFAULT_ENV, Config
@@ -124,17 +122,15 @@ def run(verify: bool = True) -> int:
         else:
             print(f"  ok{' — ' + result.detail if result.detail else ''}")
 
-    for name, value in (
-        ("DELTA_MCP_ENV", env),
-        ("DELTA_API_KEY", key),
-        ("DELTA_API_SECRET", secret),
-    ):
-        # set_key edits one line in place, leaving the template's comments and any other
-        # settings intact, so hand-editing and this command can share one file.
-        written, _, _ = set_key(str(path), name, value)
-        if not written:
-            print(f"could not write {name} to {path}", file=sys.stderr)
-            return 1
+    # One write, not three. The environment is part of what makes the key usable at all,
+    # so a half-applied save that leaves a new key beside the previous secret is worse
+    # than no save: it still reads as a complete pair and fails every signed request.
+    problem = store.write(
+        {"DELTA_MCP_ENV": env, "DELTA_API_KEY": key, "DELTA_API_SECRET": secret}
+    )
+    if problem is not None:
+        print(problem, file=sys.stderr)
+        return 1
 
     print(f"\nSaved to {path}. Restart your MCP client.")
 

--- a/src/delta_exchange_mcp/login.py
+++ b/src/delta_exchange_mcp/login.py
@@ -1,0 +1,154 @@
+"""Interactive `login` for people already sitting at a terminal.
+
+Writes the same shared settings file that hand-editing uses, so this is one of several
+ways to fill one store rather than a mechanism of its own.
+
+It refuses to run without a terminal. `getpass` on its own does not: piping into it
+prints a warning and then reads stdin anyway, so `echo $KEY | delta-exchange-mcp login`
+would quietly succeed. That is exactly the shape an agent trying to be helpful would
+reach for, and it would put the secret into shell history and into the agent's
+transcript — the two places this whole design exists to keep it out of.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import getpass
+import os
+import sys
+from dataclasses import dataclass
+
+import httpx
+from dotenv import set_key
+
+from delta_exchange_mcp import store
+from delta_exchange_mcp.client import DeltaClient
+from delta_exchange_mcp.config import BASE_URLS, DEFAULT_ENV, Config
+from delta_exchange_mcp.errors import DeltaApiError
+
+DASHBOARDS = {
+    "india_prod": "https://www.delta.exchange/app/account/manageapikeys",
+    "india_testnet": "https://demo.delta.exchange/app/account/manageapikeys",
+}
+
+
+@dataclass(frozen=True)
+class Check:
+    """Outcome of asking Delta whether the credentials work."""
+
+    ok: bool
+    reachable: bool
+    detail: str
+
+
+async def _check(env: str, key: str, secret: str) -> Check:
+    """One authenticated call, so four documented failures surface here and not later.
+
+    A wrong environment for the key, an unwhitelisted IP, a key without Read Data, and
+    a truncated paste are all invisible until something signs a request. Doing it while
+    the person is still holding the key turns each into a message they can act on.
+    """
+    cfg = Config(env=env, base_url=BASE_URLS[env], api_key=key, api_secret=secret)  # type: ignore[arg-type]
+    client = DeltaClient(cfg)
+    try:
+        profile = await client.get("/profile", auth=True)
+    except DeltaApiError as exc:
+        return Check(ok=False, reachable=True, detail=str(exc))
+    except httpx.HTTPError as exc:
+        return Check(ok=False, reachable=False, detail=f"could not reach Delta: {exc}")
+    else:
+        who = ""
+        if isinstance(profile, dict):
+            who = str(profile.get("email") or profile.get("id") or "")
+        return Check(ok=True, reachable=True, detail=who)
+    finally:
+        await client.aclose()
+
+
+def _ask_env() -> str | None:
+    prompt = f"Environment {'/'.join(sorted(BASE_URLS))}\n  [{DEFAULT_ENV}]: "
+    answer = input(prompt).strip().lower() or DEFAULT_ENV
+    if answer not in BASE_URLS:
+        print(f"  not an environment: {answer}", file=sys.stderr)
+        return None
+    return answer
+
+
+def run(verify: bool = True) -> int:
+    """Prompt for credentials and write them to the shared settings file."""
+    if not sys.stdin.isatty():
+        print(
+            "login needs a terminal. Run it yourself rather than through a pipe or an "
+            "assistant — piping would put your API secret in shell history.",
+            file=sys.stderr,
+        )
+        return 2
+
+    path = store.ensure()
+    if path is None:
+        print(f"cannot write {store.path()}", file=sys.stderr)
+        return 1
+
+    print(f"Storing credentials in {path}")
+    print("Every MCP client on this machine reads it. Leave blank to keep what is there.\n")
+
+    try:
+        env = _ask_env()
+        if env is None:
+            return 1
+        print(f"  create a key at {DASHBOARDS.get(env, DASHBOARDS[DEFAULT_ENV])}")
+        print('  the "Read Data" permission is enough unless you intend to trade\n')
+        key = getpass.getpass("API key (hidden): ").strip()
+        secret = getpass.getpass("API secret (hidden): ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print("\ncancelled, nothing written", file=sys.stderr)
+        return 1
+
+    if not key or not secret:
+        print(
+            "both a key and its secret are needed — one without the other leaves the "
+            "server on market data only",
+            file=sys.stderr,
+        )
+        return 1
+
+    if verify:
+        print(f"\nChecking against {BASE_URLS[env]} ...")
+        result = asyncio.run(_check(env, key, secret))
+        if not result.reachable:
+            # A flaky connection must not cost someone a key they typed correctly.
+            print(f"  {result.detail}\n  saving anyway, unverified", file=sys.stderr)
+        elif not result.ok:
+            print(f"  {result.detail}\n\nNothing was saved.", file=sys.stderr)
+            return 1
+        else:
+            print(f"  ok{' — ' + result.detail if result.detail else ''}")
+
+    for name, value in (
+        ("DELTA_MCP_ENV", env),
+        ("DELTA_API_KEY", key),
+        ("DELTA_API_SECRET", secret),
+    ):
+        # set_key edits one line in place, leaving the template's comments and any other
+        # settings intact, so hand-editing and this command can share one file.
+        written, _, _ = set_key(str(path), name, value)
+        if not written:
+            print(f"could not write {name} to {path}", file=sys.stderr)
+            return 1
+
+    print(f"\nSaved to {path}. Restart your MCP client.")
+
+    shadowing = [
+        name
+        for name in ("DELTA_API_KEY", "DELTA_API_SECRET", "DELTA_MCP_ENV")
+        if (os.environ.get(name) or "").strip()
+    ]
+    if shadowing:
+        # A client launched from this shell inherits these, and a client's own value
+        # always wins over the file — so the key just saved would appear to do nothing.
+        print(
+            f"\nNote: {', '.join(shadowing)} is exported in this shell and takes "
+            "precedence over the file for any client launched from here.",
+            file=sys.stderr,
+        )
+    return 0

--- a/src/delta_exchange_mcp/server.py
+++ b/src/delta_exchange_mcp/server.py
@@ -97,11 +97,28 @@ def build_parser() -> argparse.ArgumentParser:
         action="version",
         version=f"delta-exchange-mcp {PACKAGE_VERSION}",
     )
+    # Optional, so a bare invocation still means "serve" — that is how every MCP client
+    # launches this, and it must never become a subcommand.
+    sub = parser.add_subparsers(dest="command")
+    login_parser = sub.add_parser(
+        "login",
+        help="store your API key in the shared settings file, once for every client",
+    )
+    login_parser.add_argument(
+        "--no-verify",
+        action="store_true",
+        help="skip the check against Delta and save whatever is entered",
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> None:
-    build_parser().parse_args(argv)
+    args = build_parser().parse_args(argv)
+
+    if args.command == "login":
+        from delta_exchange_mcp import login
+
+        raise SystemExit(login.run(verify=not args.no_verify))
 
     cfg = config_mod.load()
     mcp = build_server(cfg)

--- a/src/delta_exchange_mcp/server.py
+++ b/src/delta_exchange_mcp/server.py
@@ -8,12 +8,13 @@ from mcp.server.fastmcp import FastMCP
 from delta_exchange_mcp import audit_log
 from delta_exchange_mcp import config as config_mod
 from delta_exchange_mcp import debug_log
+from delta_exchange_mcp import store
 from delta_exchange_mcp.client import DeltaClient
 from delta_exchange_mcp.tools import account, market, trading
 from delta_exchange_mcp.version import PACKAGE_VERSION
 
 _ENV_HELP = """\
-configuration (environment variables only — this server takes no options):
+configuration (the settings below, from your MCP client or the shared file):
   DELTA_MCP_ENV         india_prod (default), india_testnet, india_devnet
   DELTA_API_KEY         optional; requires DELTA_API_SECRET for the account tools
   DELTA_API_SECRET      required alongside DELTA_API_KEY
@@ -23,6 +24,14 @@ configuration (environment variables only — this server takes no options):
   DELTA_MCP_DEBUG_FILE  override the debug log path
   DELTA_MCP_AUDIT       off/false/0/no to disable the trade-mode audit log
   DELTA_MCP_AUDIT_FILE  override the audit log path
+  DELTA_MCP_CONFIG_FILE override the shared settings file path
+
+Each is read from the environment your MCP client launched this server with, and
+falls back to a shared file at ~/.delta-exchange-mcp/config.env that every client
+on this machine reads. That file is created with instructions in it on first run,
+so an API key is set once rather than pasted into each client's own config.
+DELTA_MCP_MODE is the exception: it is never read from the shared file, so enabling
+trading in one client cannot arm every assistant on the machine.
 
 Prod and testnet API keys are separate; DELTA_MCP_ENV must match the dashboard the
 key was created on. The server speaks MCP over stdio and is normally launched by a
@@ -104,6 +113,8 @@ def main(argv: list[str] | None = None) -> None:
         f"[delta-exchange-mcp] stdio env={cfg.env} base_url={cfg.base_url} "
         f"mode={cfg.mode} surface={surface}"
     )
+    if cfg.config_file is not None:
+        banner += f" config={cfg.config_file}"
     if trade_on:
         audit = audit_log.configure(cfg)  # idempotent: appends to the same file path
         banner += f" audit={audit.path if audit else 'off'}"
@@ -112,6 +123,9 @@ def main(argv: list[str] | None = None) -> None:
         if log_path is not None:  # configure returns None if the log file can't be opened
             banner += f" debug=on log={log_path}"
     print(banner, file=sys.stderr)
+    insecure = store.insecure_permissions()
+    if insecure is not None:
+        print(f"[delta-exchange-mcp] {insecure}", file=sys.stderr)
     if cfg.partial_credentials:
         supplied = "DELTA_API_KEY" if cfg.api_key else "DELTA_API_SECRET"
         missing = "DELTA_API_SECRET" if cfg.api_key else "DELTA_API_KEY"

--- a/src/delta_exchange_mcp/store.py
+++ b/src/delta_exchange_mcp/store.py
@@ -20,10 +20,12 @@ indistinguishable from a bad key.
 from __future__ import annotations
 
 import os
+import shutil
 import stat
+import tempfile
 from pathlib import Path
 
-from dotenv import dotenv_values
+from dotenv import dotenv_values, set_key
 
 DEFAULT_DIR = Path.home() / ".delta-exchange-mcp"
 DEFAULT_NAME = "config.env"
@@ -103,6 +105,58 @@ def ensure() -> Path | None:
     with os.fdopen(fd, "w") as handle:
         handle.write(TEMPLATE)
     return target
+
+
+def write(values: dict[str, str]) -> str | None:
+    """Set all of `values` in the shared file at once, or leave the file as it was.
+
+    The all-at-once part is the point. `set_key` rewrites the whole file and renames it
+    into place for every single key, so writing a credential one key at a time publishes
+    three successive versions of the file. A failure on the third leaves a new API key
+    sitting beside the previous secret — a pair that was never issued together, which
+    still reads as complete, still registers the account tools, and fails every signed
+    request. Staging every change on a copy and renaming once makes it all or nothing.
+
+    `set_key` still does the line editing rather than a hand-rolled rewrite, because it
+    already preserves the template's comments and quotes whatever someone can type:
+    spaces, quotes, or a stray `=` that a naive `NAME=value` append would turn into a
+    second setting.
+    """
+    target = ensure()
+    if target is None:
+        return f"cannot write {path()}"
+
+    # SHORTCUT: last writer wins. Two clients saving at the same moment each stage a
+    # complete credential, so neither can publish a mixed pair, but the earlier save is
+    # overwritten rather than merged. Upgrading that means a lock file beside the config
+    # with stale-lock recovery, which is more machinery than a once-per-setup write earns.
+    staged = None
+    try:
+        # Owner bits are carried across, group and other are dropped. A write is the one
+        # moment a *new* secret enters this file, and publishing it into a group- or
+        # world-readable file would hand it to every other account on the machine — with
+        # nothing said, because the permission warning only runs at startup. Masking here
+        # rather than forcing 0600 leaves an owner who chose 0400 with the mode they chose.
+        mode = stat.S_IMODE(target.stat().st_mode) & 0o700
+        handle, name = tempfile.mkstemp(dir=target.parent, prefix=".config-", suffix=".tmp")
+        os.close(handle)
+        staged = Path(name)
+        shutil.copyfile(target, staged)
+        for key, value in values.items():
+            written, _, _ = set_key(str(staged), key, value)
+            if not written:
+                return f"could not write {key} to {target}"
+        os.chmod(staged, mode)
+        os.replace(staged, target)
+        staged = None
+    except OSError as exc:
+        # Reported rather than raised because a caller may be a tool answering a form,
+        # where an exception becomes a protocol error the person cannot act on.
+        return f"could not write {', '.join(values)} to {target}: {exc}"
+    finally:
+        if staged is not None:
+            staged.unlink(missing_ok=True)
+    return None
 
 
 def insecure_permissions() -> str | None:

--- a/src/delta_exchange_mcp/store.py
+++ b/src/delta_exchange_mcp/store.py
@@ -1,0 +1,125 @@
+"""Settings shared by every MCP client on this machine.
+
+An MCP client's own config is an awkward home for an API key. The shape differs per
+client, it is JSON or TOML that someone non-technical has to edit without breaking,
+the same key has to be pasted again for every client, and the project-scoped variants
+(`.cursor/mcp.json`, `.vscode/mcp.json`) are files people commit. This module offers
+one plain `KEY=value` file instead, read by whichever client launched the server.
+
+The client's own environment still wins, so the Claude Desktop bundle form and
+VS Code's masked prompts keep working exactly as they do today. See `config.setting`
+for the precedence rule.
+
+Parsing goes through `python-dotenv` rather than a hand-rolled split, because the
+mistakes a non-developer makes in this file are the ones that fail silently:
+`KEY="quoted"` keeping its quotes, `export KEY=v`, a trailing `# comment`, or CRLF
+line endings all corrupt a credential in ways that surface later as a signing error
+indistinguishable from a bad key.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+DEFAULT_DIR = Path.home() / ".delta-exchange-mcp"
+DEFAULT_NAME = "config.env"
+
+TEMPLATE = """\
+# Delta Exchange MCP - settings shared by every MCP client on this machine.
+#
+# Market data works with this file empty. Fill these in to let an assistant read
+# your own account. Create a key under Account -> API Keys at
+# https://www.delta.exchange/app/account/manageapikeys with the "Read Data"
+# permission, and whitelist your IP on it.
+#
+# Match the environment to where the key came from: a key from delta.exchange
+# works only with india_prod, one from demo.delta.exchange only with
+# india_testnet. Mixing them returns InvalidApiKey.
+#
+# Your MCP client's own settings take precedence over this file.
+
+DELTA_API_KEY=
+DELTA_API_SECRET=
+DELTA_MCP_ENV=india_prod
+
+# Trading is deliberately NOT read from this file. Enable it in the config of the
+# one client you mean to trade from, so switching it on in a single place cannot
+# arm every assistant on this machine at once.
+# DELTA_MCP_MODE=trade
+"""
+
+
+def path() -> Path:
+    """Where the shared settings file lives.
+
+    `DELTA_MCP_CONFIG_FILE` overrides it, and is read from the process environment
+    only — a file cannot name itself.
+    """
+    override = (os.environ.get("DELTA_MCP_CONFIG_FILE") or "").strip()
+    return Path(override).expanduser() if override else DEFAULT_DIR / DEFAULT_NAME
+
+
+def read() -> dict[str, str]:
+    """Values from the shared file, dropping any left blank.
+
+    A missing file is the ordinary first-run state, and an unreadable one must not
+    stop market data from working, so neither is an error.
+    """
+    try:
+        return {key: value for key, value in dotenv_values(path()).items() if value}
+    except OSError:
+        return {}
+
+
+def ensure() -> Path | None:
+    """Create the file from a commented template when it is absent.
+
+    Returns the path once the file exists, or None when it could not be created —
+    a read-only or sandboxed filesystem must not stop the server from starting.
+    The template carries the instructions someone needs at the moment they open it,
+    which is the whole reason the file is written before anyone asks for it.
+    """
+    target = path()
+    try:
+        target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    except OSError:
+        # Includes FileExistsError when the parent path is an ordinary file. That means
+        # the location is unusable, which is the opposite of what the same exception
+        # means one step below, so the two cannot share a handler.
+        return None
+    try:
+        # Exclusive create rather than a prior exists() check: two clients launching
+        # the server at the same moment is normal, and one must not truncate the
+        # other's file in the gap between checking and writing.
+        fd = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        return target
+    except OSError:
+        return None
+    with os.fdopen(fd, "w") as handle:
+        handle.write(TEMPLATE)
+    return target
+
+
+def insecure_permissions() -> str | None:
+    """A warning when the file is readable by users other than its owner.
+
+    Reported rather than raised. Refusing to start would take away market data,
+    which needs no credentials at all, over a file the user may not even have
+    filled in.
+    """
+    target = path()
+    try:
+        mode = target.stat().st_mode
+    except OSError:
+        return None
+    if not mode & (stat.S_IRGRP | stat.S_IROTH):
+        return None
+    return (
+        f"{target} can hold API credentials but is readable by other users on this "
+        f"machine. Restrict it with: chmod 600 {target}"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_shared_store(tmp_path, monkeypatch):
+    """Point the shared settings file at a throwaway path for every test.
+
+    `config.load` falls back to `~/.delta-exchange-mcp/config.env`, so without this a
+    developer's own credentials would leak into the suite — `test_defaults_to_india_prod`
+    asserts no credentials are present, and would fail on any machine where that file is
+    filled in. It would also mean the suite created and wrote a real file in `$HOME`.
+
+    Autouse rather than opt-in: a test that forgets it fails only on some machines, which
+    is the worst kind of test to own.
+    """
+    monkeypatch.setenv("DELTA_MCP_CONFIG_FILE", str(tmp_path / "config.env"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,10 +44,14 @@ def test_help_documents_every_environment_variable_the_code_reads():
     import re
 
     src = pathlib.Path(__file__).resolve().parents[1] / "src"
+    # Both spellings: os.environ.get for the few reads that deliberately bypass the
+    # shared settings file, and config.setting for everything that falls back to it.
+    # Scanning only the first would let a new setting slip in undocumented.
+    pattern = r"""(?:os\.environ\.get|setting)\(["'](DELTA_[A-Z_]+)["']"""
     read_by_code = {
         name
         for path in src.rglob("*.py")
-        for name in re.findall(r"""os\.environ\.get\(["'](DELTA_[A-Z_]+)["']""", path.read_text())
+        for name in re.findall(pattern, path.read_text())
     }
     documented = set(re.findall(r"DELTA_[A-Z_]+", build_parser().format_help()))
     assert read_by_code, "env var scan found nothing — the pattern above stopped matching"

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,4 +1,6 @@
+import httpx
 import pytest
+import respx
 
 from delta_exchange_mcp import config as config_mod
 from delta_exchange_mcp import login, store
@@ -23,6 +25,51 @@ def check_returning(**kwargs):
         return login.Check(**kwargs)
 
     return fake
+
+
+@pytest.mark.parametrize(
+    ("status", "code"),
+    [(429, "rate_limit_exceeded"), (503, "service_unavailable")],
+)
+@respx.mock
+async def test_api_unavailability_is_not_a_credential_rejection(
+    monkeypatch, status, code
+):
+    """A terminal retry response says nothing about whether the credentials work."""
+
+    async def no_sleep(_delay):
+        pass
+
+    monkeypatch.setattr("delta_exchange_mcp.client.asyncio.sleep", no_sleep)
+    route = respx.get(f"{config_mod.INDIA_TESTNET_REST}/profile").mock(
+        return_value=httpx.Response(
+            status,
+            json={"success": False, "error": {"code": code}},
+        )
+    )
+
+    result = await login._check("india_testnet", "key", "secret")
+
+    assert route.call_count == 3
+    assert result.ok is False
+    assert result.reachable is False
+
+
+@respx.mock
+async def test_api_key_rejection_is_a_credential_rejection():
+    """A documented authentication failure is decisive and must prevent a save."""
+    route = respx.get(f"{config_mod.INDIA_TESTNET_REST}/profile").mock(
+        return_value=httpx.Response(
+            401,
+            json={"success": False, "error": {"code": "InvalidApiKey"}},
+        )
+    )
+
+    result = await login._check("india_testnet", "key", "secret")
+
+    assert route.call_count == 1
+    assert result.ok is False
+    assert result.reachable is True
 
 
 def test_refuses_without_a_terminal(monkeypatch, capsys):
@@ -100,6 +147,147 @@ def test_no_verify_skips_the_call(terminal, monkeypatch):
     monkeypatch.setattr(login, "_check", explode)
     assert login.run(verify=False) == 0
     assert config_mod.load().has_credentials is True
+
+
+def test_blank_answers_keep_a_saved_pair_and_its_environment(monkeypatch, capsys):
+    """Enter should mean keep, without displaying either half of the saved pair."""
+    saved_key = "saved-key-never-print"
+    saved_secret = "saved-secret-never-print"
+    assert (
+        store.write(
+            {
+                "DELTA_MCP_ENV": "india_testnet",
+                "DELTA_API_KEY": saved_key,
+                "DELTA_API_SECRET": saved_secret,
+            }
+        )
+        is None
+    )
+    monkeypatch.setattr(login.sys, "stdin", FakeTty())
+    prompts = []
+    monkeypatch.setattr("builtins.input", lambda prompt="": prompts.append(prompt) or "")
+    secret_prompts = []
+    answers = iter(["", ""])
+    monkeypatch.setattr(
+        login.getpass,
+        "getpass",
+        lambda prompt="": secret_prompts.append(prompt) or next(answers),
+    )
+    checked = []
+
+    async def successful_check(env, key, secret):
+        checked.append((env, key, secret))
+        return login.Check(ok=True, reachable=True, detail="")
+
+    monkeypatch.setattr(login, "_check", successful_check)
+
+    assert login.run() == 0
+
+    assert "[india_testnet]" in prompts[0]
+    assert all("keep" in prompt.lower() for prompt in secret_prompts)
+    assert checked == [("india_testnet", saved_key, saved_secret)]
+    assert store.read() == {
+        "DELTA_API_KEY": saved_key,
+        "DELTA_API_SECRET": saved_secret,
+        "DELTA_MCP_ENV": "india_testnet",
+    }
+    output = capsys.readouterr()
+    rendered = output.out + output.err
+    assert saved_key not in rendered
+    assert saved_secret not in rendered
+
+
+def test_changing_environment_requires_a_new_pair_even_without_verify(
+    monkeypatch, capsys
+):
+    """An old key must not be rebound to another environment by blank answers."""
+    original = {
+        "DELTA_MCP_ENV": "india_prod",
+        "DELTA_API_KEY": "prod-key",
+        "DELTA_API_SECRET": "prod-secret",
+    }
+    assert store.write(original) is None
+    monkeypatch.setattr(login.sys, "stdin", FakeTty())
+    monkeypatch.setattr("builtins.input", lambda prompt="": "india_testnet")
+    answers = iter(["", ""])
+    monkeypatch.setattr(login.getpass, "getpass", lambda prompt="": next(answers))
+
+    assert login.run(verify=False) == 1
+
+    assert "changing environments" in capsys.readouterr().err
+    assert store.read() == original
+
+
+def test_a_new_pair_can_move_the_saved_environment(monkeypatch):
+    original = {
+        "DELTA_MCP_ENV": "india_prod",
+        "DELTA_API_KEY": "prod-key",
+        "DELTA_API_SECRET": "prod-secret",
+    }
+    assert store.write(original) is None
+    monkeypatch.setattr(login.sys, "stdin", FakeTty())
+    monkeypatch.setattr("builtins.input", lambda prompt="": "india_testnet")
+    answers = iter(["testnet-key", "testnet-secret"])
+    monkeypatch.setattr(login.getpass, "getpass", lambda prompt="": next(answers))
+
+    assert login.run(verify=False) == 0
+    assert store.read() == {
+        "DELTA_API_KEY": "testnet-key",
+        "DELTA_API_SECRET": "testnet-secret",
+        "DELTA_MCP_ENV": "india_testnet",
+    }
+
+
+def test_blank_credentials_without_a_saved_pair_are_explained(monkeypatch, capsys):
+    monkeypatch.setattr(login.sys, "stdin", FakeTty())
+    monkeypatch.setattr("builtins.input", lambda prompt="": "")
+    answers = iter(["", ""])
+    monkeypatch.setattr(login.getpass, "getpass", lambda prompt="": next(answers))
+
+    assert login.run(verify=False) == 1
+
+    assert "no complete credential pair is saved" in capsys.readouterr().err.lower()
+    assert config_mod.load().has_credentials is False
+
+
+def test_a_saved_pair_without_a_valid_environment_cannot_be_kept(monkeypatch, capsys):
+    original = {"DELTA_API_KEY": "old-key", "DELTA_API_SECRET": "old-secret"}
+    path = store.path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("DELTA_API_KEY=old-key\nDELTA_API_SECRET=old-secret\n")
+    monkeypatch.setattr(login.sys, "stdin", FakeTty())
+    monkeypatch.setattr("builtins.input", lambda prompt="": "")
+    prompts = []
+    answers = iter(["", ""])
+    monkeypatch.setattr(
+        login.getpass,
+        "getpass",
+        lambda prompt="": prompts.append(prompt) or next(answers),
+    )
+
+    assert login.run(verify=False) == 1
+
+    assert all("keep" not in prompt.lower() for prompt in prompts)
+    assert "no valid environment" in capsys.readouterr().err.lower()
+    assert store.read() == original
+
+
+def test_a_partial_replacement_never_mixes_with_the_saved_pair(monkeypatch, capsys):
+    original = {
+        "DELTA_MCP_ENV": "india_testnet",
+        "DELTA_API_KEY": "old-key",
+        "DELTA_API_SECRET": "old-secret",
+    }
+    assert store.write(original) is None
+    monkeypatch.setattr(login.sys, "stdin", FakeTty())
+    monkeypatch.setattr("builtins.input", lambda prompt="": "")
+    answers = iter(["new-key", ""])
+    monkeypatch.setattr(login.getpass, "getpass", lambda prompt="": next(answers))
+
+    assert login.run(verify=False) == 1
+
+    assert "enter both to replace" in capsys.readouterr().err.lower()
+    assert store.read() == original
 
 
 def test_half_a_pair_is_refused(monkeypatch, capsys):

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,132 @@
+import pytest
+
+from delta_exchange_mcp import config as config_mod
+from delta_exchange_mcp import login, store
+
+
+class FakeTty:
+    def isatty(self):
+        return True
+
+
+@pytest.fixture
+def terminal(monkeypatch):
+    """Answer the prompts as a person at a keyboard would."""
+    monkeypatch.setattr(login.sys, "stdin", FakeTty())
+    monkeypatch.setattr("builtins.input", lambda prompt="": "india_testnet")
+    secrets = iter(["a-real-key", "a-real-secret"])
+    monkeypatch.setattr(login.getpass, "getpass", lambda prompt="": next(secrets))
+
+
+def check_returning(**kwargs):
+    async def fake(env, key, secret):
+        return login.Check(**kwargs)
+
+    return fake
+
+
+def test_refuses_without_a_terminal(monkeypatch, capsys):
+    """getpass alone would read a pipe and echo it.
+
+    `echo $KEY | delta-exchange-mcp login` is what an agent trying to help would run,
+    and it would put the secret in shell history and in that agent's transcript.
+    """
+
+    class NotATty:
+        def isatty(self):
+            return False
+
+    monkeypatch.setattr(login.sys, "stdin", NotATty())
+    assert login.run() == 2
+    assert "needs a terminal" in capsys.readouterr().err
+    assert not store.path().exists()
+
+
+def test_saves_after_a_successful_check(terminal, monkeypatch):
+    monkeypatch.setattr(login, "_check", check_returning(ok=True, reachable=True, detail=""))
+    assert login.run() == 0
+
+    cfg = config_mod.load()
+    assert (cfg.api_key, cfg.api_secret) == ("a-real-key", "a-real-secret")
+    assert cfg.env == "india_testnet"
+
+
+def test_saving_keeps_the_template_and_its_instructions(terminal, monkeypatch):
+    """The file has to stay hand-editable after login has written to it."""
+    monkeypatch.setattr(login, "_check", check_returning(ok=True, reachable=True, detail=""))
+    login.run()
+
+    body = store.path().read_text()
+    assert "Read Data" in body
+    assert "DELTA_MCP_MODE=trade" in body  # the commented-out explanation survives
+
+
+def test_a_rejected_key_is_not_saved(terminal, monkeypatch, capsys):
+    """Saving a key that does not work would register the account tools and fail every call.
+
+    That is the state placeholder credentials used to produce, and the reason the check
+    exists at all.
+    """
+    monkeypatch.setattr(
+        login,
+        "_check",
+        check_returning(
+            ok=False,
+            reachable=True,
+            detail="delta api error: InvalidApiKey — API key not found.",
+        ),
+    )
+    assert login.run() == 1
+    assert "Nothing was saved" in capsys.readouterr().err
+    assert config_mod.load().has_credentials is False
+
+
+def test_an_unreachable_api_still_saves(terminal, monkeypatch, capsys):
+    """A flaky connection must not cost someone a key they typed correctly."""
+    monkeypatch.setattr(
+        login,
+        "_check",
+        check_returning(ok=False, reachable=False, detail="could not reach Delta: timeout"),
+    )
+    assert login.run() == 0
+    assert "unverified" in capsys.readouterr().err
+    assert config_mod.load().has_credentials is True
+
+
+def test_no_verify_skips_the_call(terminal, monkeypatch):
+    async def explode(env, key, secret):
+        raise AssertionError("--no-verify must not reach the API")
+
+    monkeypatch.setattr(login, "_check", explode)
+    assert login.run(verify=False) == 0
+    assert config_mod.load().has_credentials is True
+
+
+def test_half_a_pair_is_refused(monkeypatch, capsys):
+    monkeypatch.setattr(login.sys, "stdin", FakeTty())
+    monkeypatch.setattr("builtins.input", lambda prompt="": "")
+    secrets = iter(["only-a-key", ""])
+    monkeypatch.setattr(login.getpass, "getpass", lambda prompt="": next(secrets))
+
+    assert login.run() == 1
+    assert "both a key and its secret" in capsys.readouterr().err
+    assert config_mod.load().has_credentials is False
+
+
+def test_an_unknown_environment_is_refused(monkeypatch, capsys):
+    monkeypatch.setattr(login.sys, "stdin", FakeTty())
+    monkeypatch.setattr("builtins.input", lambda prompt="": "mainnet")
+
+    assert login.run() == 1
+    assert "not an environment" in capsys.readouterr().err
+
+
+def test_a_shell_export_that_would_shadow_the_file_is_reported(terminal, monkeypatch, capsys):
+    """A client launched from this shell inherits the export, and the client always wins.
+
+    Without this the key just saved would appear to do nothing at all.
+    """
+    monkeypatch.setenv("DELTA_API_KEY", "exported-in-the-shell")
+    monkeypatch.setattr(login, "_check", check_returning(ok=True, reachable=True, detail=""))
+    assert login.run() == 0
+    assert "takes precedence over the file" in capsys.readouterr().err

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,187 @@
+import os
+import stat
+
+import pytest
+
+from delta_exchange_mcp import config as config_mod
+from delta_exchange_mcp import store
+
+
+@pytest.fixture(autouse=True)
+def no_ambient_settings(monkeypatch):
+    """Start every test from an environment that supplies nothing.
+
+    The suite inherits the developer's shell, and a stray DELTA_API_KEY there would
+    silently win over the file these tests are about.
+    """
+    for name in (
+        "DELTA_MCP_ENV",
+        "DELTA_MCP_MODE",
+        "DELTA_MCP_DEBUG",
+        "DELTA_API_KEY",
+        "DELTA_API_SECRET",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def write_store(text):
+    path = store.path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return path
+
+
+def test_template_is_created_on_first_load_owner_only():
+    cfg = config_mod.load()
+    path = store.path()
+    assert cfg.config_file == path
+    assert path.exists()
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    # The instructions someone needs are in the file, because the moment they open it
+    # is the moment they are asking these exact questions.
+    body = path.read_text()
+    assert "Read Data" in body
+    assert "india_testnet" in body
+    assert "DELTA_API_KEY=" in body
+
+
+def test_existing_file_is_never_overwritten():
+    written = write_store("DELTA_API_KEY=mine\nDELTA_API_SECRET=also-mine\n")
+    config_mod.load()
+    assert written.read_text() == "DELTA_API_KEY=mine\nDELTA_API_SECRET=also-mine\n"
+
+
+def test_unwritable_location_does_not_stop_the_server(tmp_path, monkeypatch):
+    """Market data needs no credentials, so an unusable settings file is not fatal."""
+    blocker = tmp_path / "a-file"
+    blocker.write_text("not a directory")
+    monkeypatch.setenv("DELTA_MCP_CONFIG_FILE", str(blocker / "config.env"))
+    cfg = config_mod.load()
+    assert cfg.config_file is None
+    assert cfg.env == "india_prod"
+    assert cfg.has_credentials is False
+
+
+def test_store_supplies_settings_when_the_environment_is_silent():
+    write_store("DELTA_API_KEY=k\nDELTA_API_SECRET=s\nDELTA_MCP_ENV=india_testnet\n")
+    cfg = config_mod.load()
+    assert cfg.env == "india_testnet"
+    assert cfg.base_url == config_mod.INDIA_TESTNET_REST
+    assert (cfg.api_key, cfg.api_secret) == ("k", "s")
+
+
+def test_client_environment_beats_the_store(monkeypatch):
+    write_store("DELTA_API_KEY=from-file\nDELTA_API_SECRET=from-file\n")
+    monkeypatch.setenv("DELTA_API_KEY", "from-client")
+    monkeypatch.setenv("DELTA_API_SECRET", "from-client")
+    cfg = config_mod.load()
+    assert (cfg.api_key, cfg.api_secret) == ("from-client", "from-client")
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_blank_client_values_fall_through_to_the_store(monkeypatch, blank):
+    """A bundle substitutes every variable it declares, filled in or not.
+
+    Leaving the API key field empty in the Claude Desktop form puts "" in the
+    environment. Treating that as an answer would mean the shared file could never
+    reach a bundle user at all.
+    """
+    write_store("DELTA_API_KEY=k\nDELTA_API_SECRET=s\nDELTA_MCP_ENV=india_testnet\n")
+    monkeypatch.setenv("DELTA_API_KEY", blank)
+    monkeypatch.setenv("DELTA_API_SECRET", blank)
+    monkeypatch.setenv("DELTA_MCP_ENV", blank)
+    cfg = config_mod.load()
+    assert cfg.env == "india_testnet"
+    assert (cfg.api_key, cfg.api_secret) == ("k", "s")
+
+
+def test_a_stray_key_never_pairs_with_the_stores_secret(monkeypatch):
+    """The key and secret always come from the same source.
+
+    Resolving them independently would pair a leftover key from someone's shell with
+    a secret from the file. That pair was never issued together, so every signed call
+    would fail while the server advertised the account surface as working. Taking both
+    from wherever either appears turns it into the partial-credentials warning instead.
+    """
+    write_store("DELTA_API_KEY=file-key\nDELTA_API_SECRET=file-secret\n")
+    monkeypatch.setenv("DELTA_API_KEY", "leftover-shell-key")
+    cfg = config_mod.load()
+    assert cfg.api_key == "leftover-shell-key"
+    assert cfg.api_secret is None
+    assert cfg.partial_credentials is True
+    assert cfg.has_credentials is False
+
+
+def test_trade_mode_is_never_read_from_the_store():
+    """The one setting the shared file may not supply.
+
+    Everything else there is per-machine convenience. This one places real orders, so
+    it stays scoped to the single client whose config was deliberately edited.
+    """
+    write_store("DELTA_API_KEY=k\nDELTA_API_SECRET=s\nDELTA_MCP_MODE=trade\n")
+    cfg = config_mod.load()
+    assert cfg.mode == "read"
+    assert cfg.has_credentials is True
+
+
+def test_trade_mode_still_works_from_the_client(monkeypatch):
+    write_store("DELTA_API_KEY=k\nDELTA_API_SECRET=s\n")
+    monkeypatch.setenv("DELTA_MCP_MODE", "trade")
+    assert config_mod.load().mode == "trade"
+
+
+def test_debug_and_path_overrides_come_from_the_store(tmp_path):
+    write_store(
+        "DELTA_MCP_DEBUG=1\n"
+        f"DELTA_MCP_AUDIT_FILE={tmp_path / 'audit.log'}\n"
+        f"DELTA_MCP_DEBUG_FILE={tmp_path / 'debug.log'}\n"
+    )
+    assert config_mod.load().debug is True
+    assert config_mod.setting("DELTA_MCP_AUDIT_FILE") == str(tmp_path / "audit.log")
+    assert config_mod.setting("DELTA_MCP_DEBUG_FILE") == str(tmp_path / "debug.log")
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ('DELTA_API_KEY="quoted"', "quoted"),
+        ("export DELTA_API_KEY=exported", "exported"),
+        ("DELTA_API_KEY=plain  # trailing note", "plain"),
+        ("DELTA_API_KEY = spaced", "spaced"),
+        ("DELTA_API_KEY=windows\r", "windows"),
+    ],
+)
+def test_a_hand_edited_file_survives_the_usual_mistakes(line, expected):
+    """Each of these silently corrupts a credential under a naive KEY=value split.
+
+    Three of the five then fail as a signature error indistinguishable from a wrong
+    key, which is the worst outcome for the people this file exists to help.
+    """
+    write_store(f"{line}\nDELTA_API_SECRET=s\n")
+    assert config_mod.load().api_key == expected
+
+
+def test_blank_entries_in_the_template_are_not_credentials():
+    """The shipped template has empty values; they must read as absent."""
+    config_mod.load()  # writes the template
+    cfg = config_mod.load()  # reads it back
+    assert cfg.has_credentials is False
+    assert cfg.partial_credentials is False
+    assert cfg.env == "india_prod"
+
+
+def test_world_readable_file_is_reported_not_fatal():
+    path = write_store("DELTA_API_KEY=k\nDELTA_API_SECRET=s\n")
+    os.chmod(path, 0o644)
+    warning = store.insecure_permissions()
+    assert warning is not None
+    assert "chmod 600" in warning
+    assert config_mod.load().has_credentials is True
+
+    os.chmod(path, 0o600)
+    assert store.insecure_permissions() is None
+
+
+def test_missing_file_reports_no_permission_warning(tmp_path, monkeypatch):
+    monkeypatch.setenv("DELTA_MCP_CONFIG_FILE", str(tmp_path / "absent.env"))
+    assert store.insecure_permissions() is None

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -70,6 +70,40 @@ def test_store_supplies_settings_when_the_environment_is_silent():
     assert (cfg.api_key, cfg.api_secret) == ("k", "s")
 
 
+def test_one_load_uses_one_complete_store_snapshot(monkeypatch):
+    """An atomic replacement must not be split across one Config instance."""
+    before = {
+        "DELTA_MCP_ENV": "india_testnet",
+        "DELTA_API_KEY": "before-key",
+        "DELTA_API_SECRET": "before-secret",
+        "DELTA_MCP_DEBUG": "0",
+    }
+    after = {
+        "DELTA_MCP_ENV": "india_prod",
+        "DELTA_API_KEY": "after-key",
+        "DELTA_API_SECRET": "after-secret",
+        "DELTA_MCP_DEBUG": "1",
+    }
+    reads = 0
+
+    def changing_store():
+        nonlocal reads
+        reads += 1
+        return before if reads == 1 else after
+
+    monkeypatch.setattr(store, "read", changing_store)
+
+    cfg = config_mod.load()
+
+    assert reads == 1
+    assert (cfg.env, cfg.api_key, cfg.api_secret, cfg.debug) == (
+        "india_testnet",
+        "before-key",
+        "before-secret",
+        False,
+    )
+
+
 def test_client_environment_beats_the_store(monkeypatch):
     write_store("DELTA_API_KEY=from-file\nDELTA_API_SECRET=from-file\n")
     monkeypatch.setenv("DELTA_API_KEY", "from-client")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -185,3 +185,101 @@ def test_world_readable_file_is_reported_not_fatal():
 def test_missing_file_reports_no_permission_warning(tmp_path, monkeypatch):
     monkeypatch.setenv("DELTA_MCP_CONFIG_FILE", str(tmp_path / "absent.env"))
     assert store.insecure_permissions() is None
+
+
+def test_write_creates_the_file_it_writes_into():
+    """Every front-end writes through here, and the first one to run finds no file."""
+    assert store.write({"DELTA_API_KEY": "k", "DELTA_API_SECRET": "s"}) is None
+    assert config_mod.load().has_credentials is True
+
+
+def test_write_leaves_settings_it_was_not_given_alone():
+    """Two settings written at different moments must not erase each other."""
+    write_store("DELTA_MCP_ENV=india_testnet\nDELTA_MCP_DEBUG=1\n")
+    assert store.write({"DELTA_API_KEY": "k", "DELTA_API_SECRET": "s"}) is None
+
+    cfg = config_mod.load()
+    assert (cfg.env, cfg.debug) == ("india_testnet", True)
+    assert cfg.has_credentials is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["has spaces", "quotes'and\"more", "hash#inside", "newline\ninjected", "DELTA_MCP_MODE=trade"],
+)
+def test_a_written_value_survives_being_read_back(value):
+    """A value carrying a newline or an `=` must come back as one string.
+
+    The last case would otherwise define a second setting and arm trading.
+    """
+    store.write({"DELTA_API_KEY": value, "DELTA_API_SECRET": "s"})
+    cfg = config_mod.load()
+    assert cfg.api_key == value
+    assert cfg.mode == "read"
+
+
+def test_a_failed_write_leaves_the_previous_credential_untouched(monkeypatch):
+    """A new key beside the old secret is worse than no write at all.
+
+    That pair was never issued together, so it still reads as complete, still registers
+    the account tools, and fails every signed request.
+    """
+    write_store("DELTA_API_KEY=old-key\nDELTA_API_SECRET=old-secret\n")
+    real = store.set_key
+
+    def fail_on_the_secret(target, key, value, *args, **kwargs):
+        if key == "DELTA_API_SECRET":
+            raise OSError("no space left on device")
+        return real(target, key, value, *args, **kwargs)
+
+    monkeypatch.setattr(store, "set_key", fail_on_the_secret)
+    assert store.write({"DELTA_API_KEY": "new-key", "DELTA_API_SECRET": "new-secret"}) is not None
+
+    cfg = config_mod.load()
+    assert (cfg.api_key, cfg.api_secret) == ("old-key", "old-secret")
+
+
+def test_a_failed_write_leaves_nothing_behind_beside_the_config(monkeypatch):
+    """The staging copy holds a secret, so a failure must not strand it in the directory."""
+    path = write_store("DELTA_API_KEY=old\n")
+
+    def boom(*args, **kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(store, "set_key", boom)
+    assert store.write({"DELTA_API_KEY": "new"}) is not None
+    assert [entry.name for entry in path.parent.iterdir()] == [path.name]
+
+
+def test_write_never_publishes_a_secret_into_a_file_others_can_read():
+    """Saving is the one moment a new secret enters this file.
+
+    Publishing it into a group- or world-readable file would hand it to every other
+    account on the machine, and silently — the permission warning only runs at startup.
+    """
+    path = write_store("DELTA_API_KEY=old\nDELTA_API_SECRET=old\n")
+    os.chmod(path, 0o644)
+    assert store.write({"DELTA_API_KEY": "fresh", "DELTA_API_SECRET": "fresh"}) is None
+
+    assert stat.S_IMODE(path.stat().st_mode) & (stat.S_IRGRP | stat.S_IROTH) == 0
+    assert store.insecure_permissions() is None
+
+
+def test_write_keeps_the_owner_bits_the_file_already_had():
+    """Masking group and other, not forcing 0600 — an owner who chose 0400 keeps it."""
+    path = write_store("DELTA_API_KEY=old\n")
+    os.chmod(path, 0o400)
+    store.write({"DELTA_API_KEY": "new"})
+    assert stat.S_IMODE(path.stat().st_mode) == 0o400
+
+
+def test_write_reports_a_read_only_directory_rather_than_raising():
+    """A caller may be a tool answering a form, where an exception is not actionable."""
+    path = write_store("DELTA_API_KEY=\n")
+    os.chmod(path.parent, 0o500)
+    try:
+        problem = store.write({"DELTA_API_KEY": "k"})
+    finally:
+        os.chmod(path.parent, 0o700)
+    assert problem is not None
+    assert "DELTA_API_KEY" in problem

--- a/uv.lock
+++ b/uv.lock
@@ -181,6 +181,7 @@ dependencies = [
     { name = "httpx" },
     { name = "mcp" },
     { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 
 [package.dev-dependencies]
@@ -196,6 +197,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1,<1" },
     { name = "mcp", specifier = ">=1.12.4,<2" },
     { name = "pydantic", specifier = ">=2.13.2,<3" },
+    { name = "python-dotenv", specifier = ">=1.0,<2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Why

Putting the API key in each MCP client's own config is the step people get stuck on. The shape differs per client, it is JSON or TOML someone non-technical has to edit without breaking, the same key has to be pasted again for every client, and `.cursor/mcp.json` and `.vscode/mcp.json` are files people commit.

This adds one plain `KEY=value` file that every client reads:

```
~/.delta-exchange-mcp/config.env
```

The server creates it on first run with the instructions inside it, and prints the path in its startup line. Client config entries no longer carry credentials at all — the README's install snippets drop from a nested `env` block to two keys.

## Design

**Precedence** is implemented once, in `config.setting()`: a non-empty value from the client wins, and empty means *unanswered* so it falls through to the file. That last part is what makes the bundle work — Claude Desktop substitutes every variable it declares whether or not the user filled the field, so a blank API-key box arrives as `""`. Treating it as an answer would mean the shared file could never reach a bundle user.

**`DELTA_MCP_MODE` is deliberately excluded.** Everything else in the file is per-machine convenience; that one places real orders, so it stays scoped to the single client whose config was edited rather than arming every assistant at once. Both the local Codex and Claude Desktop configs on my machine already run this server with different modes, which is exactly the case that would break.

**The credential pair is atomic.** If either the key or the secret is set in the client, both come from there; otherwise both come from the file. Resolving them independently could pair a stale key from a shell with a secret from the file — never issued together, so every signed call fails while the server reports the account surface as available. This routes it to the existing partial-credentials warning instead.

**Parsing uses `python-dotenv`** rather than a hand-rolled split. `KEY="quoted"`, `export KEY=v`, a trailing `# comment` and CRLF endings each corrupt a credential silently, and three of those then fail as a signing error indistinguishable from a wrong key. It was already in the tree via `mcp` → `pydantic-settings`; now declared because we import it.

## `login`

```bash
uvx delta-exchange-mcp login
```

Prompts with the input hidden, makes one authenticated call before saving, and refuses to save a key that Delta rejects — so wrong environment, unwhitelisted IP, missing Read Data and truncated paste all surface while the person still has the key in front of them, using the hint table `errors.py` already carries. A network failure saves anyway with a warning, so a flaky connection never costs a valid key. Writes with `set_key`, leaving the template's comments and other settings intact.

It refuses to run without a TTY. `getpass` alone does not — piping into it warns and then reads stdin anyway, so `echo $KEY | ... login` would quietly succeed and put the secret in shell history and in any agent transcript that ran it.

## Two bugs the tests caught

- `store.ensure()` treated a `FileExistsError` from `mkdir` (the location is unusable) the same as one from the exclusive create (our file is already there), returning a path for an unwritable location.
- Credentials were not stripped the way every other setting is, so a whitespace-only key counted as an answer. Stripping also absorbs the trailing newline a pasted key usually carries.

## Also fixed

`packaging/mcpb/verify.py` inherited the ambient environment and would have read the developer's real `config.env`. A `DELTA_MCP_DEBUG=1` there registers a debug tool absent from the manifest, failing the undeclared-tool check locally while passing in CI. It now redirects the file into its throwaway unpack directory, which also stops a build writing into `$HOME`.

`tests/conftest.py` does the same for the suite — without it `test_defaults_to_india_prod` fails on any machine where that file is filled in.

`tests/test_cli.py`'s undocumented-variable scan only matched `os.environ.get`, so the refactor to `setting()` silently weakened it. It now matches both.

## Verified

- `164 passed`, ruff clean across `src tests scripts packaging`
- Bundle builds and verifies: 28 tools / 0 mutating in default mode, 42 / 13 with trade; committed `manifest.json` not stale. The default count is 28 rather than 27 because this PR declares `get_debug_status`, so the verifier's ambient `DELTA_MCP_DEBUG` now registers a tool the manifest accounts for instead of exceeding it
- Credentials from the file give `surface=market+account`; a client-supplied `DELTA_MCP_ENV` overrides the file while credentials still come from it
- Bare invocation still serves — `login` is an optional subcommand, never a required one

## Not in this PR

An in-chat credential form using MCP Apps, verified working in both Claude Desktop and Codex desktop with the value never reaching model context. It writes this same file, so it stacks on top.
