### PR TITLE
Resolve every finding on the release PR

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -18,21 +18,29 @@ concurrency:
 permissions:
   contents: read
 
+# Every action here is pinned to a full commit SHA, with the tag it came from in the
+# trailing comment. A tag is a moving pointer the action's owner can repoint at any
+# commit, and this workflow builds the .mcpb that gets attached to a release and
+# installed into Claude Desktop, where it can read the user's API credentials. A SHA
+# means the bundle people download was built by the code reviewed here. To bump one,
+# resolve the new tag with `gh api repos/<owner>/<repo>/git/ref/tags/<tag>` and update
+# both the SHA and the comment together.
 jobs:
   bundle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      # setup-uv publishes no moving major tag past v7, so pin the exact release.
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # setup-uv publishes no moving major tag past v7, hence the exact release in the
+      # comment rather than a major.
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
       # The mcpb CLI is Node, and build.sh compiles it from a pinned upstream commit
       # (mcpb_cli.sh) because the published release signs bundles Claude Desktop refuses.
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .mcpb-cli
           key: mcpb-cli-${{ hashFiles('packaging/mcpb/mcpb_cli.sh') }}
@@ -49,7 +57,7 @@ jobs:
       - name: Check the committed manifest is current
         run: git diff --exit-code -- packaging/mcpb/manifest.json
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: delta-exchange-mcp-bundle
           path: packaging/mcpb/*.mcpb
@@ -62,11 +70,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: delta-exchange-mcp-bundle
-      # `gh` ships on the runner, so the only step holding contents:write runs no
-      # third-party code at all. Stronger than pinning a third-party action to a commit.
+      # The upload itself uses `gh`, which ships on the runner, so the step that actually
+      # spends contents:write runs no third-party code. The download above does, which is
+      # why it is pinned like the rest.
       #
       # Uploaded twice: the versioned name is the archival record, and the unversioned copy
       # is what /releases/latest/download/ can address, since that URL needs an asset name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,16 @@ concurrency:
 permissions:
   contents: read
 
+# Actions are pinned to a commit SHA with the tag in the trailing comment, matching
+# bundle.yml — see the note there for why and how to bump one.
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      # setup-uv publishes no moving major tag past v7, so pin the exact release.
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # setup-uv publishes no moving major tag past v7, hence the exact release.
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
       # --locked also fails when uv.lock has drifted from pyproject.toml.
@@ -33,8 +36,8 @@ jobs:
         # 3.12 is the floor declared by requires-python; 3.13 is what most users are on.
         python-version: ["3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 <div align="center">
 
-<!-- Pinned to the commit that added it: the file is not on main until this stack merges,
-     and a pinned blob stays reachable through the PR ref regardless. -->
+<!-- Pinned to a commit, not a branch. PyPI renders this file for every published version, so
+     a branch path would make an old version's page show whatever the icon is today, or break
+     outright if the file is ever moved. A pinned blob also renders from a fork or a PR ref,
+     which is what got it pinned originally, before the file reached main. -->
 <img src="https://raw.githubusercontent.com/delta-exchange/delta-exchange-mcp/d49dfba97e57120448bb4e0267abde6d7931e5f1/packaging/mcpb/icon.png" width="88" alt="Delta Exchange">
 
 # delta-exchange-mcp
@@ -27,11 +29,11 @@ explicit opt-in flag.
 
 ## Use it — no setup
 
-Hit **Download for Claude Desktop** above and double-click the file. Claude Desktop shows a
-form, then installs the server — no config file, and **no need to install `uv` or Python
-first**: the app fetches both itself. Unlike the Cursor and VS Code buttons, this one is a
-file download rather than a link that configures your editor; bundles are read only by Claude
-Desktop, Claude Code, and MCP for Windows.
+Hit **Download for Claude Desktop** above, take the `.mcpb` file from the newest release, and
+double-click it. Claude Desktop shows a form, then installs the server — no config file, and
+**no need to install `uv` or Python first**: the app fetches both itself. Unlike the Cursor and
+VS Code buttons, this one hands you a file to open rather than configuring your editor for
+you; bundles are read only by Claude Desktop, Claude Code, and MCP for Windows.
 
 The form has four fields:
 
@@ -657,7 +659,13 @@ Please redact `api_key` / `api_secret` from any logs or screenshots before attac
 [vs-code-insiders-badge]: https://img.shields.io/badge/VS_Code_Insiders-Install_Server-24bfa5?style=for-the-badge&logo=githubcopilot&logoColor=white
 [vs-code-insiders-link]: https://insiders.vscode.dev/redirect/mcp/install?name=delta-exchange-mcp&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22delta-exchange-mcp%22%5D%2C%22env%22%3A%7B%22DELTA_MCP_ENV%22%3A%22%24%7Binput%3Adelta-env%7D%22%2C%22DELTA_API_KEY%22%3A%22%24%7Binput%3Adelta-api-key%7D%22%2C%22DELTA_API_SECRET%22%3A%22%24%7Binput%3Adelta-api-secret%7D%22%7D%7D&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22delta-api-key%22%2C%22description%22%3A%22Delta%20API%20key%20%28leave%20empty%20for%20market%20data%20only%29%22%2C%22password%22%3Atrue%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22delta-api-secret%22%2C%22description%22%3A%22Delta%20API%20secret%20%28must%20match%20the%20key%29%22%2C%22password%22%3Atrue%7D%2C%7B%22type%22%3A%22pickString%22%2C%22id%22%3A%22delta-env%22%2C%22description%22%3A%22Delta%20Exchange%20environment%22%2C%22options%22%3A%5B%22india_prod%22%2C%22india_testnet%22%5D%2C%22default%22%3A%22india_prod%22%7D%5D&quality=insiders
 [claude-desktop-badge]: https://img.shields.io/badge/Claude_Desktop-Download_bundle-D97757?style=for-the-badge&logo=claude&logoColor=white
-[claude-desktop-link]: https://github.com/delta-exchange/delta-exchange-mcp/releases/latest/download/delta-exchange-mcp.mcpb
+<!-- The releases page, not /latest/download/delta-exchange-mcp.mcpb. That direct URL 404s
+     whenever the newest release carries no bundle — true of v0.4.2, which was tagged before
+     the workflow that attaches one existed, and true again of any release whose attach job
+     fails. This is the first install path on the page, so it must not depend on release
+     timing. The direct URL still works for scripted installs once an asset is attached; see
+     RELEASING.md. -->
+[claude-desktop-link]: https://github.com/delta-exchange/delta-exchange-mcp/releases/latest
 [claude-code-jump-badge]: https://img.shields.io/badge/Claude_Code-setup_below-6e7681?style=for-the-badge&logo=claude&logoColor=white
 [claude-code-jump-link]: #claude-code
 [codex-jump-badge]: https://img.shields.io/badge/Codex-setup_below-6e7681?style=for-the-badge&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0yMi4yODIgOS44MjFhNS45ODUgNS45ODUgMCAwIDAtLjUxNi00LjkxIDYuMDQ2IDYuMDQ2IDAgMCAwLTYuNTEtMi45QTYuMDY1IDYuMDY1IDAgMCAwIDQuOTgxIDQuMThhNS45ODUgNS45ODUgMCAwIDAtMy45OTggMi45IDYuMDQ2IDYuMDQ2IDAgMCAwIC43NDMgNy4wOTcgNS45OCA1Ljk4IDAgMCAwIC41MSA0LjkxMSA2LjA1MSA2LjA1MSAwIDAgMCA2LjUxNSAyLjlBNS45ODUgNS45ODUgMCAwIDAgMTMuMjYgMjRhNi4wNTYgNi4wNTYgMCAwIDAgNS43NzItNC4yMDYgNS45OSA1Ljk5IDAgMCAwIDMuOTk3LTIuOSA2LjA1NiA2LjA1NiAwIDAgMC0uNzQ3LTcuMDczek0xMy4yNiAyMi40M2E0LjQ3NiA0LjQ3NiAwIDAgMS0yLjg3Ni0xLjA0bC4xNDEtLjA4MSA0Ljc3OS0yLjc1OGEuNzk1Ljc5NSAwIDAgMCAuMzkyLS42ODF2LTYuNzM3bDIuMDIgMS4xNjhhLjA3MS4wNzEgMCAwIDEgLjAzOC4wNTJ2NS41ODNhNC41MDQgNC41MDQgMCAwIDEtNC40OTQgNC40OTR6TTMuNiAxOC4zMDRhNC40NyA0LjQ3IDAgMCAxLS41MzUtMy4wMTRsLjE0Mi4wODUgNC43ODMgMi43NTlhLjc3MS43NzEgMCAwIDAgLjc4IDBsNS44NDMtMy4zNjl2Mi4zMzJhLjA4LjA4IDAgMCAxLS4wMzMuMDYyTDkuNzQgMTkuOTVhNC41IDQuNSAwIDAgMS02LjE0LTEuNjQ2ek0yLjM0IDcuODk2YTQuNDg1IDQuNDg1IDAgMCAxIDIuMzY2LTEuOTczVjExLjZhLjc2Ni43NjYgMCAwIDAgLjM4OC42NzdsNS44MTUgMy4zNTQtMi4wMiAxLjE2OGEuMDc2LjA3NiAwIDAgMS0uMDcxIDBsLTQuODMtMi43ODZBNC41MDQgNC41MDQgMCAwIDEgMi4zNCA3Ljg3MnptMTYuNTk3IDMuODU1LTUuODMzLTMuMzg3TDE1LjExOSA3LjJhLjA3Ni4wNzYgMCAwIDEgLjA3MSAwbDQuODMgMi43OTFhNC40OTQgNC40OTQgMCAwIDEtLjY3NiA4LjEwNXYtNS42NzhhLjc5Ljc5IDAgMCAwLS40MDctLjY2N3ptMi4wMS0zLjAyMy0uMTQxLS4wODUtNC43NzQtMi43ODJhLjc3Ni43NzYgMCAwIDAtLjc4NSAwTDkuNDA5IDkuMjNWNi44OTdhLjA2Ni4wNjYgMCAwIDEgLjAyOC0uMDYxbDQuODMtMi43ODdhNC41IDQuNSAwIDAgMSA2LjY4IDQuNjZ6TTguMzA1IDEyLjg2M2wtMi4wMi0xLjE2NGEuMDguMDggMCAwIDEtLjAzOC0uMDU3VjYuMDc1YTQuNSA0LjUgMCAwIDEgNy4zNzUtMy40NTNsLS4xNDIuMDhMOC43IDUuNDZhLjc5NS43OTUgMCAwIDAtLjM5My42ODF6bTEuMDk3LTIuMzY1IDIuNjAyLTEuNSAyLjYwNyAxLjV2Mi45OTlsLTIuNTk3IDEuNS0yLjYwNy0xLjV6Ii8%2BPC9zdmc%2B

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,12 @@ This covers: bumping the version, publishing to PyPI, tagging, drafting the GitH
 
 ## What gets versioned
 
-The `version` field in `pyproject.toml` is the single source of truth. The `delta-exchange-mcp/<version>` string in `User-Agent` and `Source` request headers is derived from it (see `src/delta_exchange_mcp/client.py`, which reads `importlib.metadata.version("delta-exchange-mcp")`). Bumping the field is enough; nothing else in the code needs to change.
+The `version` field in `pyproject.toml` is the single source of truth. The `delta-exchange-mcp/<version>` string in `User-Agent` and `Source` request headers is derived from it (see `src/delta_exchange_mcp/client.py`, which reads `importlib.metadata.version("delta-exchange-mcp")`). Nothing else in the *code* needs to change.
+
+Two committed files do, though, and both are checked in CI:
+
+- **`uv.lock`** pins the workspace's own version. `uv sync` refreshes it.
+- **`packaging/mcpb/manifest.json`** is generated but committed, so the shipped bundle contract is reviewable in a diff. It carries the version, and the Bundle workflow runs on any change to `pyproject.toml` and then enforces `git diff --exit-code -- packaging/mcpb/manifest.json`. **A version bump with a stale manifest turns the Bundle check red.** Regenerate it in step 3 below.
 
 SemVer while in Beta:
 
@@ -20,6 +25,7 @@ SemVer while in Beta:
 2. A **project-scoped** PyPI API token created under *Manage project → Settings → Create a token*. Store it locally as `UV_PUBLISH_TOKEN` (e.g. in your shell rc or 1Password). Never check it in. Do not reuse account-scoped tokens past the initial-claim release.
 3. `gh` CLI logged in (`gh auth status` is green).
 4. Clean working tree on an up-to-date `main` (`git status` empty, `git pull --ff-only`).
+5. **Node 22+**, for regenerating the bundle manifest. `packaging/mcpb/build.sh` compiles the `mcpb` CLI from a pinned upstream commit rather than installing the npm release, because the published one signs bundles Claude Desktop refuses. First run takes a few minutes; after that it is cached.
 
 ## Cut a release
 
@@ -31,13 +37,18 @@ NEW_VERSION=0.1.1
 sed -i '' "s/^version = \".*\"/version = \"$NEW_VERSION\"/" pyproject.toml
 git diff pyproject.toml          # sanity check the diff
 
-# 3. Run tests + lint locally
+# 3. Run tests + lint, and regenerate the bundle
 uv sync                          # regenerates uv.lock with the new workspace version
 uv run pytest
-uv run ruff check src tests scripts
+uv run ruff check src tests scripts packaging
+
+# The manifest carries the version and is committed, so it goes stale on every bump. This
+# rebuilds and verifies the whole bundle; the only tracked file it changes is manifest.json.
+bash packaging/mcpb/build.sh
+git diff --stat packaging/mcpb/manifest.json   # expect the version field, and tools if they moved
 
 # 4. Commit + tag
-git add pyproject.toml uv.lock   # uv.lock pins the workspace's own version; keep them in sync
+git add pyproject.toml uv.lock packaging/mcpb/manifest.json
 git commit -m "Release v$NEW_VERSION"
 git tag -a "v$NEW_VERSION" -m "v$NEW_VERSION"
 
@@ -94,7 +105,19 @@ uvx --refresh delta-exchange-mcp --help
 # 3. Smoke test public tools through the freshly-spawned server
 bash scripts/inspect.sh --cli --method tools/list
 bash scripts/inspect.sh --cli --method tools/call --tool-name get_ticker --tool-arg symbol=BTCUSD
+
+# 4. The bundle actually attached. The Bundle workflow's attach job fires on
+#    `release: published` only, so a draft release gets no asset — and the README's
+#    Claude Desktop install path is only useful once one is there.
+gh release view "v$NEW_VERSION" --json assets -q '.assets[].name'
+curl -sIL -o /dev/null -w '%{http_code}\n' \
+  "https://github.com/delta-exchange/delta-exchange-mcp/releases/latest/download/delta-exchange-mcp.mcpb"
 ```
+
+Expect two asset names — `delta-exchange-mcp-<version>.mcpb` and the unversioned
+`delta-exchange-mcp.mcpb` alias — and `200` from the curl. The alias exists so that
+`/releases/latest/download/` has a name that does not change between releases; without it
+that URL 404s, which is why the README badge points at the releases page instead.
 
 ## Rolling back a bad release
 

--- a/packaging/mcpb/make_bundle.py
+++ b/packaging/mcpb/make_bundle.py
@@ -88,7 +88,17 @@ USER_CONFIG = {
 def project() -> dict:
     """The repo's own [project] table — the single source of truth for shared metadata."""
     with (REPO / "pyproject.toml").open("rb") as f:
-        return tomllib.load(f)["project"]
+        proj = tomllib.load(f)["project"]
+    # render_manifest copies this straight through, and the manifest schema wants an SPDX
+    # string. PEP 639 spells it that way; the older `{ text = "MIT" }` table would land in
+    # the JSON as a nested object and fail validation with a message that names the field
+    # and not the cause. Checked here because this is the one place the file is read.
+    if not isinstance(proj.get("license"), str):
+        raise SystemExit(
+            f"[project].license must be an SPDX string, got {proj.get('license')!r} — "
+            "the manifest schema has no place for the table form"
+        )
+    return proj
 
 
 def wheel_name(proj: dict) -> str:
@@ -119,18 +129,31 @@ def render_pyproject(proj: dict) -> str:
 async def tool_entries() -> list[dict[str, str]]:
     """Introspect the server to list every tool the bundle can register.
 
-    The environment is forced rather than defaulted so the manifest depends only on the
-    source being packaged, never on the shell the build ran in — real exported credentials
-    would otherwise be read at build time for no reason.
+    Every DELTA_ variable is cleared before the ones that matter are set, so the manifest
+    depends only on the source being packaged and never on the shell the build ran in.
+    Forcing a named few was not enough. A developer with DELTA_MCP_DEBUG=1 exported got
+    `get_debug_status` written into the manifest — 42 tools instead of 41 — and CI, whose
+    shell has no such variable, then rejects that manifest as stale. DELTA_MCP_ENV leaked
+    the same way, where an invalid value in the shell failed the build inside `load()`.
 
     Trade mode is forced because the declared list has to be the *superset*. `tools_generated`
     is false, which promises the runtime never exposes anything beyond this list, and a user
     who sets Mode to trade reaches all of it. Listing only the read surface would break that
     promise the moment someone opted in.
     """
-    os.environ["DELTA_MCP_MODE"] = "trade"
-    os.environ["DELTA_API_KEY"] = "placeholder"
-    os.environ["DELTA_API_SECRET"] = "placeholder"
+    for name in [name for name in os.environ if name.startswith("DELTA_")]:
+        del os.environ[name]
+    os.environ.update({
+        "DELTA_MCP_MODE": "trade",
+        "DELTA_MCP_ENV": "india_prod",
+        "DELTA_API_KEY": "placeholder",
+        "DELTA_API_SECRET": "placeholder",
+        # Trade mode plus credentials is what opens the audit log, and listing tool names
+        # mutates nothing worth auditing. Left on, every manifest build dropped another
+        # empty file into ~/.delta-exchange-mcp/audit/, which is where 4,493 of them
+        # came from.
+        "DELTA_MCP_AUDIT": "off",
+    })
     from delta_exchange_mcp.server import build_server
 
     tools = await build_server().list_tools()

--- a/packaging/mcpb/verify.py
+++ b/packaging/mcpb/verify.py
@@ -7,12 +7,14 @@ fails here rather than on someone's machine.
 
 import json
 import os
+import queue
 import re
 import shutil
 import struct
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import zipfile
 from pathlib import Path
@@ -100,6 +102,23 @@ def launch_env(manifest: dict, mode: str) -> dict[str, str]:
     return env
 
 
+def _pump(stream, put) -> None:
+    """Move one of the child's output pipes somewhere the main thread can reach it.
+
+    Reading a pipe directly blocks until a newline arrives or the writer closes it, with no
+    way to give up. A bundle that starts but never answers is precisely what this verifier
+    exists to catch, and read inline it would hold the build until the runner's own job
+    timeout hours later instead of failing on the deadline below. Draining stderr matters
+    for the same reason from the other direction: a child that fills the stderr pipe buffer
+    while nobody reads it blocks before it ever replies on stdout.
+    """
+    try:
+        for line in iter(stream.readline, ""):
+            put(line)
+    finally:
+        put(None)
+
+
 def handshake(
     extracted: Path, env: dict[str, str] | None = None, timeout: float = 240.0
 ) -> list[str]:
@@ -113,6 +132,17 @@ def handshake(
         bufsize=1,
         env=env,
     )
+
+    replies: queue.Queue = queue.Queue()
+    errors: list[str] = []
+    readers = [
+        threading.Thread(target=_pump, args=(proc.stdout, replies.put), daemon=True),
+        threading.Thread(
+            target=_pump, args=(proc.stderr, lambda line: line and errors.append(line)), daemon=True
+        ),
+    ]
+    for reader in readers:
+        reader.start()
 
     def send(msg: dict) -> None:
         proc.stdin.write(json.dumps(msg) + "\n")
@@ -134,9 +164,12 @@ def handshake(
     deadline = time.time() + timeout
     seen: dict[int, dict] = {}
     asked = False
-    while time.time() < deadline and 2 not in seen:
-        line = proc.stdout.readline()
-        if not line:
+    while 2 not in seen:
+        try:
+            line = replies.get(timeout=max(0.0, deadline - time.time()))
+        except queue.Empty:  # the deadline passed with the child still alive and silent
+            break
+        if line is None:  # the child closed stdout
             break
         line = line.strip()
         if not line:
@@ -157,11 +190,16 @@ def handshake(
         proc.wait(timeout=15)
     except subprocess.TimeoutExpired:
         proc.kill()
+    # Give the readers a moment to finish now the writer is gone, so the diagnostics below
+    # carry everything the child managed to say rather than whatever had arrived by then.
+    for reader in readers:
+        reader.join(timeout=5)
 
+    tail = "".join(errors)[-2000:]
     if 1 not in seen:
-        raise SystemExit(f"no initialize response\nstderr:\n{proc.stderr.read()[-2000:]}")
+        raise SystemExit(f"no initialize response\nstderr:\n{tail}")
     if 2 not in seen:
-        raise SystemExit(f"no tools/list response\nstderr:\n{proc.stderr.read()[-2000:]}")
+        raise SystemExit(f"no tools/list response\nstderr:\n{tail}")
 
     info = seen[1]["result"].get("serverInfo", {})
     print(f"  handshake: initialize OK, serverInfo={info}")

--- a/src/delta_exchange_mcp/config.py
+++ b/src/delta_exchange_mcp/config.py
@@ -66,8 +66,14 @@ def load() -> Config:
     return Config(
         env=env,  # type: ignore[arg-type]
         base_url=BASE_URLS[env],
-        api_key=os.environ.get("DELTA_API_KEY") or None,
-        api_secret=os.environ.get("DELTA_API_SECRET") or None,
+        # Stripped for the same reason env and mode are, and it matters more here. These
+        # are the two fields someone pastes into a form, so they carry the trailing newline
+        # a copy from the dashboard brings with it. Left unstripped, a whitespace-only value
+        # is truthy: has_credentials goes true, the account tools register, and
+        # partial_credentials stays false so the startup warning never fires. Every signed
+        # call then fails while the server reports the account surface as available.
+        api_key=(os.environ.get("DELTA_API_KEY") or "").strip() or None,
+        api_secret=(os.environ.get("DELTA_API_SECRET") or "").strip() or None,
         debug=os.environ.get("DELTA_MCP_DEBUG", "").strip().lower() in TRUTHY,
         mode=mode,  # type: ignore[arg-type]
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,40 @@ def test_blank_env_and_mode_fall_back_to_defaults(monkeypatch, value):
     assert cfg.mode == "read"
 
 
+@pytest.mark.parametrize("value", ["", "   ", "\n", "\t "])
+def test_blank_credentials_read_as_absent(monkeypatch, value):
+    """Whitespace is truthy, which would make an unfilled form field look like a key.
+
+    The account tools would register, `partial_credentials` would stay false so the startup
+    warning never fires, and every signed call would fail — the server insisting it can read
+    your account while nothing works.
+    """
+    monkeypatch.setenv("DELTA_API_KEY", value)
+    monkeypatch.setenv("DELTA_API_SECRET", value)
+    cfg = config_mod.load()
+    assert (cfg.api_key, cfg.api_secret) == (None, None)
+    assert cfg.has_credentials is False
+    assert cfg.partial_credentials is False
+
+
+def test_a_pasted_credential_keeps_its_trailing_newline_out(monkeypatch):
+    """Copying from the dashboard brings a newline, which breaks signing, not the load."""
+    monkeypatch.setenv("DELTA_API_KEY", "  a-real-key\n")
+    monkeypatch.setenv("DELTA_API_SECRET", "a-real-secret\n")
+    cfg = config_mod.load()
+    assert (cfg.api_key, cfg.api_secret) == ("a-real-key", "a-real-secret")
+
+
+def test_a_whitespace_only_key_is_not_a_half_supplied_pair(monkeypatch):
+    """The case the warning was added for, arriving as whitespace rather than as unset."""
+    monkeypatch.setenv("DELTA_API_KEY", "a-real-key")
+    monkeypatch.setenv("DELTA_API_SECRET", "   ")
+    cfg = config_mod.load()
+    assert cfg.has_credentials is False
+    # Reported, not silent: this is exactly what the startup warning exists to say.
+    assert cfg.partial_credentials is True
+
+
 def test_credentials_loaded_from_env(monkeypatch):
     monkeypatch.setenv("DELTA_API_KEY", "k")
     monkeypatch.setenv("DELTA_API_SECRET", "s")


### PR DESCRIPTION
Resolves every finding on the release PR #50 — the two Greptile threads plus four issues found reviewing it by hand, and two smaller notes. All of them are in the release path, which is why they are worth settling before that path publishes anything rather than after.

## 1. A blank credential field registered account tools that could never work

`load()` gained `.strip()` on `DELTA_MCP_ENV` and `DELTA_MCP_MODE` because a bundle form submits a value for every declared field whether or not the user filled it in. The two fields someone actually pastes into never got the same treatment.

Whitespace is truthy. A cleared or space-only API key field therefore gave `api_key = "   "`, `has_credentials` went true, `account.register` ran, and `partial_credentials` stayed false so the new startup warning never fired. Every signed call then failed with `InvalidApiKey` or a signature mismatch while the server reported the account surface as available — the least diagnosable state it has. A key pasted with a trailing newline did the same thing.

Both are stripped now, with tests for the whitespace-only case, the trailing-newline case, and the mixed case where a real key sits beside a blank secret and the warning *should* fire.

## 2. The README's first install path was a 404

`Download for Claude Desktop` pointed at `/releases/latest/download/delta-exchange-mcp.mcpb`. The newest release is `v0.4.2`, tagged before the workflow that attaches a bundle existed, so it carries zero assets and that URL 404s. Every click on the front page's first call-to-action failed.

It now points at the releases page. That resolves whether or not the newest release carried an asset, so the front page cannot be broken by release timing or by a future `attach` job that fails — a durable property rather than a stopgap someone has to remember to undo. The direct URL still works for scripted installs once an asset exists, and `RELEASING.md` now verifies it.

## 3. RELEASING.md never mentioned the bundle

`packaging/mcpb/manifest.json` is generated but committed, so the shipped contract is reviewable in a diff. It carries the version, and `bundle.yml` runs on any change to `pyproject.toml` and then enforces `git diff --exit-code` on it. So a version bump with a stale manifest turns the Bundle check red, and fixing it needs Node and a from-source build of the upstream `mcpb` CLI. The runbook contained no reference to `manifest`, `mcpb`, or `bundle` at all.

Added: what gets versioned beyond `pyproject.toml`, Node as a prerequisite with the reason the CLI is built from source, the `build.sh` step, `manifest.json` in the `git add`, and a post-release check that the asset actually attached — because `attach` fires on `release: published` only, so a draft release silently produces no bundle.

## 4. The manifest depended on the shell that built it

`tool_entries()` claimed to force the environment "so the manifest depends only on the source being packaged, never on the shell the build ran in". It forced `DELTA_MCP_MODE` and two placeholder credentials, and nothing else.

Reproduced rather than argued. With `DELTA_MCP_DEBUG=1` exported:

```
wrote manifest.json (42 tools, version 0.4.2)
get_debug_status leaked: True
```

That is a tool written into the committed manifest that CI's own shell will not register, which makes the manifest stale and the Bundle check red. `DELTA_MCP_ENV` leaked the same way, where an invalid value in the shell failed the build inside `load()`.

Forcing `mode=trade` with credentials also opens the audit log, so every manifest generation dropped an empty file into `~/.delta-exchange-mcp/audit/`. There are **4,493** of them on my machine.

Every `DELTA_` variable is now cleared before the five that matter are set, which makes the docstring true instead of aspirational. Same hostile shell, after:

```
wrote manifest.json (41 tools, version 0.4.2)
get_debug_status leaked: False
audit files: 4494 -> 4494
```

and the result is byte-identical to the committed manifest.

## 5. Mutable action tags (Greptile P2, security)

`bundle.yml` referenced every action by a moving tag. A tag is a pointer its owner can repoint at any commit, and this workflow builds the `.mcpb` that gets attached to a release and installed into Claude Desktop, where it can read the user's API key and secret. Whoever controls one of those tags controls the artifact people download.

Every action in both workflows now carries a full commit SHA with its tag in a trailing comment, plus a note on how to bump one. `ci.yml` is included for one convention rather than half a repo pinned for unstated reasons; it holds only `contents: read` and cannot touch an artifact, so that part is consistency, not exposure.

A comment in the `attach` job was also wrong. It claimed the job holding `contents: write` "runs no third-party code at all" — but that job runs `actions/download-artifact` before the `gh` upload. The `gh` half is genuinely first-party; the download never was.

## 6. A timeout that did not time out (Greptile P2)

`handshake()` declares 240 seconds and checked the deadline in its loop condition, but the body called `proc.stdout.readline()`, which blocks until a newline arrives or the writer closes the pipe. A bundle that starts and then goes silent — precisely what this verifier exists to catch — never reaches the deadline check, so the build would hang until the runner's own job timeout hours later.

Measured against a child that starts, stays alive and writes nothing, at a 3-second timeout:

- before: still hanging when killed at 25s
- after: `gave up after 3.0s: no initialize response`

Both pipes are drained on threads and the deadline is enforced by `queue.get(timeout=...)`. stderr is drained for the same reason from the other direction: a child that fills the stderr buffer while nobody reads it blocks before it can reply on stdout. That also makes the failure diagnostics complete, where the previous `proc.stderr.read()` ran after the process was killed and could truncate.

## Smaller notes

`make_bundle.py` read `proj["license"]` as a string and copied it into the manifest. True for the PEP 639 form, and the older `{ text = "MIT" }` table would land in the JSON as a nested object and fail `mcpb validate` with a message naming the field and not the cause. It now fails at the point the file is read, with the cause. Confirmed the guard fires rather than being dead code.

The README's hero-icon comment said the image was pinned because "the file is not on main until this stack merges", which #50 makes stale. The pin stays — switching to a branch path would break the image on `develop` today, and PyPI renders this file per published version, so a branch path would make an old version's page show whatever the icon is now. The comment now gives the reason that survives the merge.

## Verified

- `124 passed`, `ruff check src tests scripts packaging` clean
- Bundle builds and verifies unchanged: 27 tools / 0 mutating by default, 41 / 13 under trade
- `packaging/mcpb/manifest.json` byte-identical, including from a deliberately hostile shell
- README: 50 balanced fences, 7 balanced `<details>`, every JSON fence parses, no broken anchors, no undefined or unused link references

## Merge note

Item 1 touches the same lines `#51` rewrites into `_credentials()`, so merging that PR after this one conflicts in `src/delta_exchange_mcp/config.py` and nowhere else. `#51`'s version is the one to keep: it strips both halves *and* takes them from a single source, so a stray `DELTA_API_KEY` in a shell cannot pair with a secret from the shared file. Everything else across both branches auto-merges.
