### PR TITLE
Declare the debug tool so an ambient variable cannot exceed the manifest

### DIFF
--- a/packaging/mcpb/make_bundle.py
+++ b/packaging/mcpb/make_bundle.py
@@ -154,25 +154,30 @@ async def tool_entries() -> list[dict[str, str]]:
     """
     for name in [name for name in os.environ if name.startswith("DELTA_")]:
         del os.environ[name]
-    os.environ.update({
-        "DELTA_MCP_MODE": "trade",
-        "DELTA_MCP_ENV": "india_prod",
-        "DELTA_MCP_DEBUG": "1",
-        # Both logs are redirected into a throwaway directory. Introspecting a tool list
-        # produces nothing worth keeping, and left at their defaults each manifest build
-        # dropped another file into ~/.delta-exchange-mcp/.
-        "DELTA_MCP_DEBUG_FILE": str(pathlib.Path(tempfile.mkdtemp()) / "debug.log"),
-        "DELTA_API_KEY": "placeholder",
-        "DELTA_API_SECRET": "placeholder",
-        # Trade mode plus credentials is what opens the audit log, and listing tool names
-        # mutates nothing worth auditing. Left on, every manifest build dropped another
-        # empty file into ~/.delta-exchange-mcp/audit/, which is where 4,493 of them
-        # came from.
-        "DELTA_MCP_AUDIT": "off",
-    })
-    from delta_exchange_mcp.server import build_server
 
-    tools = await build_server().list_tools()
+    # Scratch directory rather than a bare mkdtemp, because turning debug on means the
+    # server opens a log file and nothing here wants to keep it. A bare mkdtemp is not
+    # removed by anyone, so every build would leave a directory and a log behind for the
+    # operating system to reap eventually — trading files left in the home directory for
+    # files left in /tmp, which is not the fix it looks like.
+    with tempfile.TemporaryDirectory(prefix="mcpb-manifest-") as scratch:
+        os.environ.update({
+            "DELTA_MCP_MODE": "trade",
+            "DELTA_MCP_ENV": "india_prod",
+            "DELTA_MCP_DEBUG": "1",
+            "DELTA_MCP_DEBUG_FILE": str(pathlib.Path(scratch) / "debug.log"),
+            "DELTA_API_KEY": "placeholder",
+            "DELTA_API_SECRET": "placeholder",
+            # Trade mode plus credentials is what opens the audit log, and listing tool
+            # names mutates nothing worth auditing. Left on, every manifest build dropped
+            # another empty file into ~/.delta-exchange-mcp/audit/, which is where 4,493
+            # of them came from.
+            "DELTA_MCP_AUDIT": "off",
+        })
+        from delta_exchange_mcp.server import build_server
+
+        tools = await build_server().list_tools()
+
     return [
         {
             "name": t.name,

--- a/packaging/mcpb/make_bundle.py
+++ b/packaging/mcpb/make_bundle.py
@@ -12,6 +12,7 @@ import json
 import os
 import pathlib
 import sys
+import tempfile
 import tomllib
 
 HERE = pathlib.Path(__file__).resolve().parent
@@ -131,21 +132,36 @@ async def tool_entries() -> list[dict[str, str]]:
 
     Every DELTA_ variable is cleared before the ones that matter are set, so the manifest
     depends only on the source being packaged and never on the shell the build ran in.
-    Forcing a named few was not enough. A developer with DELTA_MCP_DEBUG=1 exported got
-    `get_debug_status` written into the manifest — 42 tools instead of 41 — and CI, whose
-    shell has no such variable, then rejects that manifest as stale. DELTA_MCP_ENV leaked
-    the same way, where an invalid value in the shell failed the build inside `load()`.
+    Forcing a named few was not enough: a developer with DELTA_MCP_DEBUG=1 exported got a
+    different manifest than CI produced, and CI then rejected it as stale. DELTA_MCP_ENV
+    leaked the same way, where an invalid value in the shell failed the build inside `load()`.
 
-    Trade mode is forced because the declared list has to be the *superset*. `tools_generated`
-    is false, which promises the runtime never exposes anything beyond this list, and a user
-    who sets Mode to trade reaches all of it. Listing only the read surface would break that
-    promise the moment someone opted in.
+    Every optional surface is then forced ON, because the declared list has to be the
+    *superset*. `tools_generated` is false, which promises the runtime never exposes anything
+    beyond this list, so anything a user can switch on has to already be in it:
+
+    * Trade mode, reached through the install form's Mode field.
+    * Debug, which registers `get_debug_status`. Nothing in the manifest declares
+      DELTA_MCP_DEBUG, and the manifest env is applied *over* the user's environment, so an
+      exported DELTA_MCP_DEBUG=1 reaches an installed bundle untouched — measured: 28 tools
+      registered against 41 declared, with `get_debug_status` among neither.
+
+    Declaring DELTA_MCP_DEBUG="" in the manifest would also stop that, but it would take
+    away the only way a bundle user can turn debug logging on at all — and that log is how
+    they capture wire-level evidence for a bug report, since a bundle has no config file to
+    edit. Listing the tool costs nothing by comparison: `tools_generated: false` promises a
+    ceiling, not an exact set, which is already how the 13 mutating tools are handled.
     """
     for name in [name for name in os.environ if name.startswith("DELTA_")]:
         del os.environ[name]
     os.environ.update({
         "DELTA_MCP_MODE": "trade",
         "DELTA_MCP_ENV": "india_prod",
+        "DELTA_MCP_DEBUG": "1",
+        # Both logs are redirected into a throwaway directory. Introspecting a tool list
+        # produces nothing worth keeping, and left at their defaults each manifest build
+        # dropped another file into ~/.delta-exchange-mcp/.
+        "DELTA_MCP_DEBUG_FILE": str(pathlib.Path(tempfile.mkdtemp()) / "debug.log"),
         "DELTA_API_KEY": "placeholder",
         "DELTA_API_SECRET": "placeholder",
         # Trade mode plus credentials is what opens the audit log, and listing tool names

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -92,6 +92,10 @@
       "description": "OHLC candles. For funding/mark/OI history prefer the dedicated tools"
     },
     {
+      "name": "get_debug_status",
+      "description": "Whether debug logging is on and the absolute path of the current log file."
+    },
+    {
       "name": "get_fills",
       "description": "Your trade fills (executed trades). Paginated. Timestamps are microseconds."
     },

--- a/packaging/mcpb/verify.py
+++ b/packaging/mcpb/verify.py
@@ -77,7 +77,7 @@ def check_archive(mcpb: Path) -> None:
     print(f"  payload: {', '.join(sorted(required))}, {wheels.pop()}")
 
 
-def launch_env(manifest: dict, mode: str) -> dict[str, str]:
+def launch_env(manifest: dict, mode: str, workdir: Path) -> dict[str, str]:
     """The environment a host would build, over a deliberately hostile one.
 
     The ambient half sets DELTA_MCP_MODE=trade and supplies credentials, which is what a
@@ -85,6 +85,17 @@ def launch_env(manifest: dict, mode: str) -> dict[str, str]:
     ${user_config.x} resolved the way the host resolves it. Checking the result is what
     makes "the form decides the mode, not the environment" an actual test rather than an
     assertion that passes because no credentials were present.
+
+    DELTA_MCP_DEBUG is in the ambient half and *not* declared by the manifest, which is the
+    point: the manifest env is applied over the user's environment, so an undeclared variable
+    reaches the server untouched and registers `get_debug_status`. Left out of here, the
+    undeclared-tool check in `main` could only ever pass, because CI's own shell has no such
+    variable. With it, that check is what proves the declared list is a real ceiling.
+
+    Turning debug on means the server writes a log, and trade mode with credentials opens an
+    audit log, so both are pointed at `workdir` — the throwaway unpack. Left at their
+    defaults, every build dropped two debug logs and an audit file into the developer's
+    ~/.delta-exchange-mcp, which is not somewhere a build should be writing at all.
     """
     config = {k: v.get("default", "") for k, v in manifest["user_config"].items()}
     config.update({"mode": mode, "api_key": "placeholder", "api_secret": "placeholder"})
@@ -94,6 +105,9 @@ def launch_env(manifest: dict, mode: str) -> dict[str, str]:
         "DELTA_MCP_MODE": "trade",
         "DELTA_API_KEY": "ambient",
         "DELTA_API_SECRET": "ambient",
+        "DELTA_MCP_DEBUG": "1",
+        "DELTA_MCP_DEBUG_FILE": str(workdir / "debug.log"),
+        "DELTA_MCP_AUDIT_FILE": str(workdir / "audit.log"),
     })
     for key, raw in manifest["server"]["mcp_config"]["env"].items():
         env[key] = re.sub(
@@ -219,7 +233,9 @@ def main() -> None:
 
         # Someone who accepted the form's defaults, on a machine whose environment is
         # already asking for trade mode. The declared default has to win.
-        default = handshake(tmp, launch_env(manifest, manifest["user_config"]["mode"]["default"]))
+        default = handshake(
+            tmp, launch_env(manifest, manifest["user_config"]["mode"]["default"], tmp)
+        )
         leaked = [n for n in default if n.startswith(MUTATION_PREFIXES)]
         print(f"  default mode: {len(default)} tools, {len(leaked)} mutating")
         if leaked:
@@ -231,15 +247,18 @@ def main() -> None:
             raise SystemExit("no tools registered")
 
         # And the opt-in has to actually reach trading, or the field is decorative.
-        opted = handshake(tmp, launch_env(manifest, "trade"))
+        opted = handshake(tmp, launch_env(manifest, "trade", tmp))
         mutating = [n for n in opted if n.startswith(MUTATION_PREFIXES)]
         print(f"  mode=trade:   {len(opted)} tools, {len(mutating)} mutating")
         if not mutating:
             raise SystemExit("opting into trade registered no mutation tools")
 
         # tools_generated is false, which promises the manifest lists everything reachable.
+        # Both runs, not just the trade one: an undeclared tool that a variable in the user's
+        # own environment switches on appears in the default install too, and that is the
+        # install almost everyone has.
         declared = {t["name"] for t in manifest["tools"]}
-        undeclared = set(opted) - declared
+        undeclared = (set(default) | set(opted)) - declared
         if undeclared:
             raise SystemExit(
                 "manifest declares tools_generated=false but the server registers "


### PR DESCRIPTION
Follow-up to the review comment on #50. Confirmed, and fixed differently from the suggested remedy — reasoning below, happy to be overruled.

## The defect

`manifest.json` declares four environment variables and `tools_generated: false`, which promises the runtime never exposes anything beyond the declared tool list. The manifest `env` is applied *over* the user's environment, so an undeclared variable reaches an installed bundle untouched. `DELTA_MCP_DEBUG` is undeclared, and it registers `get_debug_status`.

Reproduced against the built `0.5.0` bundle, installed with form defaults, from a shell exporting `DELTA_MCP_DEBUG=1`:

```
manifest declares: 41 tools | tools_generated = False
declared env keys: ['DELTA_MCP_MODE', 'DELTA_MCP_ENV', 'DELTA_API_KEY', 'DELTA_API_SECRET']
DELTA_MCP_DEBUG reaching the server: '1'
registered: 28 tools
UNDECLARED at runtime: ['get_debug_status']
```

`verify.py` could not catch this, because its ambient environment inherits from the build shell and CI has no such variable.

## Why not declare `DELTA_MCP_DEBUG=""`

That closes the hole, but it takes away the only way a bundle user can turn debug logging on. A bundle has no config file to edit, so an ambient export is the only channel they have — and that log is how they capture wire-level evidence for a bug report. Trading a user's ability to diagnose a problem for a manifest invariant seemed like the wrong side of the trade.

It also does not close the hole completely once the shared settings file lands (#51): `config.setting` falls back to `~/.delta-exchange-mcp/config.env`, so a `DELTA_MCP_DEBUG=1` line in that file switches the tool on regardless of what the manifest declares.

## What this does instead

Forces debug on during manifest generation, so `get_debug_status` is declared. The list becomes the ceiling it claims to be, from every channel — ambient export, shared settings file, or anything added later.

This is the argument already in `tool_entries` for trade mode, applied to the other optional surface: "the declared list has to be the *superset* ... listing only the read surface would break that promise the moment someone opted in." `tools_generated: false` promises a ceiling, not an exact set, which is already how the 13 mutating tools are handled — a read-mode user never sees those either.

Bundle now verifies at **28 tools / 0 mutating** by default and **42 / 13** under trade, against 42 declared.

## The regression guard

Declaring the tool alone would let the next undeclared surface slip through the same way, so the check that failed to catch this is fixed too.

`launch_env` builds a deliberately hostile ambient environment. `DELTA_MCP_DEBUG=1` now belongs in it, precisely *because* the manifest does not declare it — that is what makes the undeclared-tool assertion meaningful rather than vacuous. That assertion also now covers the default-mode run and not only the trade run, since an undeclared tool switched on by the user's own environment appears in the default install, which is the install almost everyone has.

Verified the guard is not decoration, by dropping `get_debug_status` from the manifest — reproducing exactly what `develop` shipped — and re-running:

```
doctored manifest declares: 41 tools
default=28 trade=42
guard would fire: True -> ['get_debug_status']
```

## A build no longer writes to your home directory

Turning debug on in the verifier means the server writes a log, and trade mode with credentials opens an audit log. Both are now pointed at the throwaway unpack directory. Before this, every `build.sh` run left two debug logs and an audit file in `~/.delta-exchange-mcp/` — which is where the 4,493 empty audit files on my machine came from. Measured across a full build: `logs: 5 -> 5 | audit: 4504 -> 4504`.

## `DELTA_MCP_AUDIT` and `DELTA_MCP_AUDIT_FILE`

Considered and left alone, for a different reason in each case. Neither changes the tool list, so neither affects the `tools_generated` promise. Declaring `DELTA_MCP_AUDIT=""` would mean a bundle user can never disable the audit log — defensible for a tool that places real orders, but it is a capability removal rather than an invariant fix, and worth deciding on its own merits rather than folding in here. `DELTA_MCP_AUDIT_FILE` is the more interesting one: an ambient value silently redirects a trading audit log somewhere unexpected, which looks like it is working. Happy to add both if you want them.

## Verified

- `124 passed`, `ruff check src tests scripts packaging` clean
- Bundle builds and verifies: 28 / 0 default, 42 / 13 trade, against 42 declared
- Committed `manifest.json` regenerates identically

## One thing to decide

`manifest.json` still says `0.5.0`, but now with 42 tools where the `v0.5.0` tag has 41. Two different manifests under one version number — the same problem that held up the release. It happens to be easy to fix right now, because `v0.5.0` was tagged but never published: there is no GitHub Release and PyPI is still on `0.4.2`, so nothing has shipped under that number yet. Either re-cut `v0.5.0` from this, or bump. Your call as release owner.
