### PR TITLE
Make the Claude Desktop badge download the bundle directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ explicit opt-in flag.
 
 ## Use it — no setup
 
-Hit **Download for Claude Desktop** above, take the `.mcpb` file from the newest release, and
-double-click it. Claude Desktop shows a form, then installs the server — no config file, and
-**no need to install `uv` or Python first**: the app fetches both itself. Unlike the Cursor and
-VS Code buttons, this one hands you a file to open rather than configuring your editor for
-you; bundles are read only by Claude Desktop, Claude Code, and MCP for Windows.
+Hit **Download for Claude Desktop** above and double-click the file. Claude Desktop shows a
+form, then installs the server — no config file, and **no need to install `uv` or Python
+first**: the app fetches both itself. Unlike the Cursor and VS Code buttons, this one is a
+file download rather than a link that configures your editor; bundles are read only by Claude
+Desktop, Claude Code, and MCP for Windows.
 
 The form has four fields:
 
@@ -659,13 +659,11 @@ Please redact `api_key` / `api_secret` from any logs or screenshots before attac
 [vs-code-insiders-badge]: https://img.shields.io/badge/VS_Code_Insiders-Install_Server-24bfa5?style=for-the-badge&logo=githubcopilot&logoColor=white
 [vs-code-insiders-link]: https://insiders.vscode.dev/redirect/mcp/install?name=delta-exchange-mcp&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22delta-exchange-mcp%22%5D%2C%22env%22%3A%7B%22DELTA_MCP_ENV%22%3A%22%24%7Binput%3Adelta-env%7D%22%2C%22DELTA_API_KEY%22%3A%22%24%7Binput%3Adelta-api-key%7D%22%2C%22DELTA_API_SECRET%22%3A%22%24%7Binput%3Adelta-api-secret%7D%22%7D%7D&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22delta-api-key%22%2C%22description%22%3A%22Delta%20API%20key%20%28leave%20empty%20for%20market%20data%20only%29%22%2C%22password%22%3Atrue%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22delta-api-secret%22%2C%22description%22%3A%22Delta%20API%20secret%20%28must%20match%20the%20key%29%22%2C%22password%22%3Atrue%7D%2C%7B%22type%22%3A%22pickString%22%2C%22id%22%3A%22delta-env%22%2C%22description%22%3A%22Delta%20Exchange%20environment%22%2C%22options%22%3A%5B%22india_prod%22%2C%22india_testnet%22%5D%2C%22default%22%3A%22india_prod%22%7D%5D&quality=insiders
 [claude-desktop-badge]: https://img.shields.io/badge/Claude_Desktop-Download_bundle-D97757?style=for-the-badge&logo=claude&logoColor=white
-<!-- The releases page, not /latest/download/delta-exchange-mcp.mcpb. That direct URL 404s
-     whenever the newest release carries no bundle — true of v0.4.2, which was tagged before
-     the workflow that attaches one existed, and true again of any release whose attach job
-     fails. This is the first install path on the page, so it must not depend on release
-     timing. The direct URL still works for scripted installs once an asset is attached; see
-     RELEASING.md. -->
-[claude-desktop-link]: https://github.com/delta-exchange/delta-exchange-mcp/releases/latest
+<!-- Downloads the bundle directly. This addresses the unversioned alias rather than the
+     versioned filename, because /releases/latest/download/ needs an asset name that does not
+     change between releases; the attach job uploads both. It 404s if the newest release
+     carries no bundle, which is why RELEASING.md curls this exact URL after publishing. -->
+[claude-desktop-link]: https://github.com/delta-exchange/delta-exchange-mcp/releases/latest/download/delta-exchange-mcp.mcpb
 [claude-code-jump-badge]: https://img.shields.io/badge/Claude_Code-setup_below-6e7681?style=for-the-badge&logo=claude&logoColor=white
 [claude-code-jump-link]: #claude-code
 [codex-jump-badge]: https://img.shields.io/badge/Codex-setup_below-6e7681?style=for-the-badge&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0yMi4yODIgOS44MjFhNS45ODUgNS45ODUgMCAwIDAtLjUxNi00LjkxIDYuMDQ2IDYuMDQ2IDAgMCAwLTYuNTEtMi45QTYuMDY1IDYuMDY1IDAgMCAwIDQuOTgxIDQuMThhNS45ODUgNS45ODUgMCAwIDAtMy45OTggMi45IDYuMDQ2IDYuMDQ2IDAgMCAwIC43NDMgNy4wOTcgNS45OCA1Ljk4IDAgMCAwIC41MSA0LjkxMSA2LjA1MSA2LjA1MSAwIDAgMCA2LjUxNSAyLjlBNS45ODUgNS45ODUgMCAwIDAgMTMuMjYgMjRhNi4wNTYgNi4wNTYgMCAwIDAgNS43NzItNC4yMDYgNS45OSA1Ljk5IDAgMCAwIDMuOTk3LTIuOSA2LjA1NiA2LjA1NiAwIDAgMC0uNzQ3LTcuMDczek0xMy4yNiAyMi40M2E0LjQ3NiA0LjQ3NiAwIDAgMS0yLjg3Ni0xLjA0bC4xNDEtLjA4MSA0Ljc3OS0yLjc1OGEuNzk1Ljc5NSAwIDAgMCAuMzkyLS42ODF2LTYuNzM3bDIuMDIgMS4xNjhhLjA3MS4wNzEgMCAwIDEgLjAzOC4wNTJ2NS41ODNhNC41MDQgNC41MDQgMCAwIDEtNC40OTQgNC40OTR6TTMuNiAxOC4zMDRhNC40NyA0LjQ3IDAgMCAxLS41MzUtMy4wMTRsLjE0Mi4wODUgNC43ODMgMi43NTlhLjc3MS43NzEgMCAwIDAgLjc4IDBsNS44NDMtMy4zNjl2Mi4zMzJhLjA4LjA4IDAgMCAxLS4wMzMuMDYyTDkuNzQgMTkuOTVhNC41IDQuNSAwIDAgMS02LjE0LTEuNjQ2ek0yLjM0IDcuODk2YTQuNDg1IDQuNDg1IDAgMCAxIDIuMzY2LTEuOTczVjExLjZhLjc2Ni43NjYgMCAwIDAgLjM4OC42NzdsNS44MTUgMy4zNTQtMi4wMiAxLjE2OGEuMDc2LjA3NiAwIDAgMS0uMDcxIDBsLTQuODMtMi43ODZBNC41MDQgNC41MDQgMCAwIDEgMi4zNCA3Ljg3MnptMTYuNTk3IDMuODU1LTUuODMzLTMuMzg3TDE1LjExOSA3LjJhLjA3Ni4wNzYgMCAwIDEgLjA3MSAwbDQuODMgMi43OTFhNC40OTQgNC40OTQgMCAwIDEtLjY3NiA4LjEwNXYtNS42NzhhLjc5Ljc5IDAgMCAwLS40MDctLjY2N3ptMi4wMS0zLjAyMy0uMTQxLS4wODUtNC43NzQtMi43ODJhLjc3Ni43NzYgMCAwIDAtLjc4NSAwTDkuNDA5IDkuMjNWNi44OTdhLjA2Ni4wNjYgMCAwIDEgLjAyOC0uMDYxbDQuODMtMi43ODdhNC41IDQuNSAwIDAgMSA2LjY4IDQuNjZ6TTguMzA1IDEyLjg2M2wtMi4wMi0xLjE2NGEuMDguMDggMCAwIDEtLjAzOC0uMDU3VjYuMDc1YTQuNSA0LjUgMCAwIDEgNy4zNzUtMy40NTNsLS4xNDIuMDhMOC43IDUuNDZhLjc5NS43OTUgMCAwIDAtLjM5My42ODF6bTEuMDk3LTIuMzY1IDIuNjAyLTEuNSAyLjYwNyAxLjV2Mi45OTlsLTIuNTk3IDEuNS0yLjYwNy0xLjV6Ii8%2BPC9zdmc%2B


### PR DESCRIPTION
The **Download for Claude Desktop** badge opens the releases page and makes you find the file, instead of downloading it. It now downloads directly.

## Why it was pointing at the page

I changed it in #53, because `/releases/latest/download/delta-exchange-mcp.mcpb` returned 404. That was accurate at the time: the newest release was `v0.4.2`, tagged before the workflow that attaches a bundle existed, so it carried no assets and the front page's first call to action was dead.

That reason has expired. `v0.5.0` shipped with both assets, so the URL resolves — and it will keep resolving, because the `attach` job uploads the unversioned alias with `--clobber` on every release. The alias exists precisely so `/releases/latest/download/` has a name that does not change between versions.

## Verified against the live URL

```
http status:  200
content-type: application/octet-stream
bytes:        97889
valid zip, entries: 6
manifest version: 0.5.0 | tools: 41
```

So the badge hands over a real bundle, not a page.

## The failure mode this reintroduces, and why it is covered

The direct URL 404s again if a future release carries no bundle — an `attach` job that fails, or a release published before the workflow runs. That is no longer silent: `RELEASING.md` curls this exact URL as a post-release step and expects `200`, alongside listing the attached asset names. Catching it in the runbook is better than routing every user through an extra click forever.

## Verified

README structure unchanged: 50 balanced fences, 7 balanced `<details>`, every JSON fence parses, no broken anchors, no undefined or unused link references.

## Where this shows up

The default branch is `main`, so the repo front page keeps showing the releases-page link until the next `develop -> main` promotion. PyPI renders the README from the published package, so its copy updates on the next release rather than on merge.
