### PR TITLE
Release v0.5.1: harden the bundle manifest and direct download

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -7,6 +7,13 @@ on:
       - "src/**"
       - "pyproject.toml"
       - ".github/workflows/bundle.yml"
+  push:
+    branches: [develop]
+    paths:
+      - "packaging/mcpb/**"
+      - "src/**"
+      - "pyproject.toml"
+      - ".github/workflows/bundle.yml"
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           enable-cache: true
       # --locked also fails when uv.lock has drifted from pyproject.toml.
       - run: uv sync --locked
-      - run: uv run ruff check src tests scripts
+      - run: uv run ruff check src tests scripts packaging
 
   test:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,9 @@ Each tool module exposes `register(mcp: FastMCP, client: DeltaClient) -> None` t
 `tools/trading.py` exposes the authenticated write tools (place/edit/cancel order, cancel-all, place/edit/cancel batch, place/edit bracket, set-leverage, change-margin, close-all, auto-topup). Its `register(mcp, client, audit)` is gated on `(cfg.has_credentials and cfg.mode == "trade")` in `build_server`; `DELTA_MCP_MODE` defaults to `read`, so the surface is off unless explicitly opted into.
 
 Conventions in `trading.py`:
+- Register every mutation through the shared `@mutation_tool` decorator. It publishes
+  `_meta["delta.exchange/mutating"] = true`, which the bundle verifier uses instead of
+  inferring safety from tool-name prefixes.
 - Every mutating tool takes `dry_run: bool`. The shared `_finish(tool, method, path, payload, dry_run)` helper strips `None` keys, and when `dry_run` returns `{dry_run, method, path, payload}` **without** any HTTP call; otherwise it sends via `client.post/put/delete` and records to the audit log on both success and `DeltaApiError`.
 - Order-level boolean flags (`post_only`, `reduce_only`, `cancel_*`) are Delta **string enums** — convert with `_bs()` to `"true"`/`"false"`. Position-level flags (`auto_topup`, `close_all_*`) are real JSON booleans.
 - `close_all_positions` needs `user_id`; it is auto-resolved from `/profile` once and cached per-process in the `register` closure — never a tool param.

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ explicit opt-in flag.
 
 ## Use it — no setup
 
-Hit **Download for Claude Desktop** above, take the `.mcpb` file from the newest release, and
-double-click it. Claude Desktop shows a form, then installs the server — no config file, and
-**no need to install `uv` or Python first**: the app fetches both itself. Unlike the Cursor and
-VS Code buttons, this one hands you a file to open rather than configuring your editor for
-you; bundles are read only by Claude Desktop, Claude Code, and MCP for Windows.
+Hit **Download for Claude Desktop** above and double-click the file. Claude Desktop shows a
+form, then installs the server — no config file, and **no need to install `uv` or Python
+first**: the app fetches both itself. Unlike the Cursor and VS Code buttons, this one is a
+file download rather than a link that configures your editor; bundles are read only by Claude
+Desktop, Claude Code, and MCP for Windows.
 
 The form has four fields:
 
@@ -659,13 +659,11 @@ Please redact `api_key` / `api_secret` from any logs or screenshots before attac
 [vs-code-insiders-badge]: https://img.shields.io/badge/VS_Code_Insiders-Install_Server-24bfa5?style=for-the-badge&logo=githubcopilot&logoColor=white
 [vs-code-insiders-link]: https://insiders.vscode.dev/redirect/mcp/install?name=delta-exchange-mcp&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22delta-exchange-mcp%22%5D%2C%22env%22%3A%7B%22DELTA_MCP_ENV%22%3A%22%24%7Binput%3Adelta-env%7D%22%2C%22DELTA_API_KEY%22%3A%22%24%7Binput%3Adelta-api-key%7D%22%2C%22DELTA_API_SECRET%22%3A%22%24%7Binput%3Adelta-api-secret%7D%22%7D%7D&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22delta-api-key%22%2C%22description%22%3A%22Delta%20API%20key%20%28leave%20empty%20for%20market%20data%20only%29%22%2C%22password%22%3Atrue%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22delta-api-secret%22%2C%22description%22%3A%22Delta%20API%20secret%20%28must%20match%20the%20key%29%22%2C%22password%22%3Atrue%7D%2C%7B%22type%22%3A%22pickString%22%2C%22id%22%3A%22delta-env%22%2C%22description%22%3A%22Delta%20Exchange%20environment%22%2C%22options%22%3A%5B%22india_prod%22%2C%22india_testnet%22%5D%2C%22default%22%3A%22india_prod%22%7D%5D&quality=insiders
 [claude-desktop-badge]: https://img.shields.io/badge/Claude_Desktop-Download_bundle-D97757?style=for-the-badge&logo=claude&logoColor=white
-<!-- The releases page, not /latest/download/delta-exchange-mcp.mcpb. That direct URL 404s
-     whenever the newest release carries no bundle — true of v0.4.2, which was tagged before
-     the workflow that attaches one existed, and true again of any release whose attach job
-     fails. This is the first install path on the page, so it must not depend on release
-     timing. The direct URL still works for scripted installs once an asset is attached; see
-     RELEASING.md. -->
-[claude-desktop-link]: https://github.com/delta-exchange/delta-exchange-mcp/releases/latest
+<!-- Downloads the bundle directly. This addresses the unversioned alias rather than the
+     versioned filename, because /releases/latest/download/ needs an asset name that does not
+     change between releases; the attach job uploads both. It 404s if the newest release
+     carries no bundle, which is why RELEASING.md curls this exact URL after publishing. -->
+[claude-desktop-link]: https://github.com/delta-exchange/delta-exchange-mcp/releases/latest/download/delta-exchange-mcp.mcpb
 [claude-code-jump-badge]: https://img.shields.io/badge/Claude_Code-setup_below-6e7681?style=for-the-badge&logo=claude&logoColor=white
 [claude-code-jump-link]: #claude-code
 [codex-jump-badge]: https://img.shields.io/badge/Codex-setup_below-6e7681?style=for-the-badge&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0yMi4yODIgOS44MjFhNS45ODUgNS45ODUgMCAwIDAtLjUxNi00LjkxIDYuMDQ2IDYuMDQ2IDAgMCAwLTYuNTEtMi45QTYuMDY1IDYuMDY1IDAgMCAwIDQuOTgxIDQuMThhNS45ODUgNS45ODUgMCAwIDAtMy45OTggMi45IDYuMDQ2IDYuMDQ2IDAgMCAwIC43NDMgNy4wOTcgNS45OCA1Ljk4IDAgMCAwIC41MSA0LjkxMSA2LjA1MSA2LjA1MSAwIDAgMCA2LjUxNSAyLjlBNS45ODUgNS45ODUgMCAwIDAgMTMuMjYgMjRhNi4wNTYgNi4wNTYgMCAwIDAgNS43NzItNC4yMDYgNS45OSA1Ljk5IDAgMCAwIDMuOTk3LTIuOSA2LjA1NiA2LjA1NiAwIDAgMC0uNzQ3LTcuMDczek0xMy4yNiAyMi40M2E0LjQ3NiA0LjQ3NiAwIDAgMS0yLjg3Ni0xLjA0bC4xNDEtLjA4MSA0Ljc3OS0yLjc1OGEuNzk1Ljc5NSAwIDAgMCAuMzkyLS42ODF2LTYuNzM3bDIuMDIgMS4xNjhhLjA3MS4wNzEgMCAwIDEgLjAzOC4wNTJ2NS41ODNhNC41MDQgNC41MDQgMCAwIDEtNC40OTQgNC40OTR6TTMuNiAxOC4zMDRhNC40NyA0LjQ3IDAgMCAxLS41MzUtMy4wMTRsLjE0Mi4wODUgNC43ODMgMi43NTlhLjc3MS43NzEgMCAwIDAgLjc4IDBsNS44NDMtMy4zNjl2Mi4zMzJhLjA4LjA4IDAgMCAxLS4wMzMuMDYyTDkuNzQgMTkuOTVhNC41IDQuNSAwIDAgMS02LjE0LTEuNjQ2ek0yLjM0IDcuODk2YTQuNDg1IDQuNDg1IDAgMCAxIDIuMzY2LTEuOTczVjExLjZhLjc2Ni43NjYgMCAwIDAgLjM4OC42NzdsNS44MTUgMy4zNTQtMi4wMiAxLjE2OGEuMDc2LjA3NiAwIDAgMS0uMDcxIDBsLTQuODMtMi43ODZBNC41MDQgNC41MDQgMCAwIDEgMi4zNCA3Ljg3MnptMTYuNTk3IDMuODU1LTUuODMzLTMuMzg3TDE1LjExOSA3LjJhLjA3Ni4wNzYgMCAwIDEgLjA3MSAwbDQuODMgMi43OTFhNC40OTQgNC40OTQgMCAwIDEtLjY3NiA4LjEwNXYtNS42NzhhLjc5Ljc5IDAgMCAwLS40MDctLjY2N3ptMi4wMS0zLjAyMy0uMTQxLS4wODUtNC43NzQtMi43ODJhLjc3Ni43NzYgMCAwIDAtLjc4NSAwTDkuNDA5IDkuMjNWNi44OTdhLjA2Ni4wNjYgMCAwIDEgLjAyOC0uMDYxbDQuODMtMi43ODdhNC41IDQuNSAwIDAgMSA2LjY4IDQuNjZ6TTguMzA1IDEyLjg2M2wtMi4wMi0xLjE2NGEuMDguMDggMCAwIDEtLjAzOC0uMDU3VjYuMDc1YTQuNSA0LjUgMCAwIDEgNy4zNzUtMy40NTNsLS4xNDIuMDhMOC43IDUuNDZhLjc5NS43OTUgMCAwIDAtLjM5My42ODF6bTEuMDk3LTIuMzY1IDIuNjAyLTEuNSAyLjYwNyAxLjV2Mi45OTlsLTIuNTk3IDEuNS0yLjYwNy0xLjV6Ii8%2BPC9zdmc%2B

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -116,8 +116,10 @@ curl -sIL -o /dev/null -w '%{http_code}\n' \
 
 Expect two asset names — `delta-exchange-mcp-<version>.mcpb` and the unversioned
 `delta-exchange-mcp.mcpb` alias — and `200` from the curl. The alias exists so that
-`/releases/latest/download/` has a name that does not change between releases; without it
-that URL 404s, which is why the README badge points at the releases page instead.
+`/releases/latest/download/` has a name that does not change between releases, and the README
+badge points directly at it. The Bundle workflow's `attach` job uploads the alias only after
+the release is published, so the direct link can briefly return 404 while that job runs. Wait
+for the attach job and this curl to succeed before announcing the release.
 
 ## Rolling back a bad release
 

--- a/packaging/mcpb/README.md
+++ b/packaging/mcpb/README.md
@@ -52,6 +52,8 @@ until all of this passes:
 - two real MCP **handshakes** against a fresh unpack — `initialize`, then `tools/list`
 - **the form decides the mode, not the environment**: accepting the declared default
   registers no mutation tool even when the ambient environment says `DELTA_MCP_MODE=trade`
+- **mutations identify themselves**: every trading tool carries the namespaced
+  `_meta["delta.exchange/mutating"]` marker, so the verifier does not infer safety from names
 - **the opt-in works**: `trade` reaches all 13 mutation tools, so the field is not decorative
 - **nothing undeclared**: every tool the server registers appears in the manifest, which is
   what `tools_generated: false` promises

--- a/packaging/mcpb/README.md
+++ b/packaging/mcpb/README.md
@@ -56,13 +56,15 @@ until all of this passes:
 - **nothing undeclared**: every tool the server registers appears in the manifest, which is
   what `tools_generated: false` promises
 
-Both handshakes start from a deliberately hostile environment — `DELTA_MCP_MODE=trade` and
-credentials exported — and then apply the manifest's `env` over it with `${user_config.x}`
-resolved the way a host resolves it. That is what makes the first check meaningful. An earlier
-version simply launched the server with no credentials and asserted zero mutations, which
-passed because mutation tools are gated on credentials *and* trade mode: it could not have
-failed. Confirm any change here still fails when `DELTA_MCP_MODE` is removed from the
-manifest's `env`, which is the bug the check exists to catch.
+Both handshakes start from a deliberately hostile environment — `DELTA_MCP_MODE=trade`,
+credentials and `DELTA_MCP_DEBUG=1` exported — and then apply the manifest's `env` over it with
+`${user_config.x}` resolved the way a host resolves it. Debug and audit output are redirected
+into the throwaway unpack so a build never writes to `~/.delta-exchange-mcp`. That is what makes
+the mode and undeclared-tool checks meaningful. An earlier version simply launched the server
+with no credentials and asserted zero mutations, which passed because mutation tools are gated
+on credentials *and* trade mode: it could not have failed. Confirm any change here still fails
+when `DELTA_MCP_MODE` is removed from the manifest's `env`, which is the bug the check exists to
+catch.
 
 ## The icon
 
@@ -91,10 +93,12 @@ start.
 ## Decisions
 
 **Trading is present but opt-in.** `DELTA_MCP_MODE` is a `user_config` field defaulting to
-`read`, substituted into the launch environment as `${user_config.mode}`. Someone who accepts
-the form gets 27 tools and no mutations; someone who types `trade` gets 41 and can place real
-orders. `user_config` has no enum type — only string, number, boolean, directory and file —
-so this is a free-text string, the same shape as the `environment` field beside it.
+`read`, substituted into the launch environment as `${user_config.mode}`. With credentials and
+debug off, `read` gets 27 tools and no mutations; `trade` gets 41 and can place real orders.
+The verifier intentionally enables debug and therefore sees 28 and 42 respectively, with
+`get_debug_status` as the extra declared tool. `user_config` has no enum type — only string,
+number, boolean, directory and file — so this is a free-text string, the same shape as the
+`environment` field beside it.
 
 Declaring the variable matters as much as its default. Leaving it out of the manifest entirely
 would let an ambient `DELTA_MCP_MODE=trade` in the environment the app was launched with reach

--- a/packaging/mcpb/make_bundle.py
+++ b/packaging/mcpb/make_bundle.py
@@ -144,7 +144,7 @@ async def tool_entries() -> list[dict[str, str]]:
     * Debug, which registers `get_debug_status`. Nothing in the manifest declares
       DELTA_MCP_DEBUG, and the manifest env is applied *over* the user's environment, so an
       exported DELTA_MCP_DEBUG=1 reaches an installed bundle untouched — measured: 28 tools
-      registered against 41 declared, with `get_debug_status` among neither.
+      registered against 41 declared, with `get_debug_status` registered but undeclared.
 
     Declaring DELTA_MCP_DEBUG="" in the manifest would also stop that, but it would take
     away the only way a bundle user can turn debug logging on at all — and that log is how
@@ -174,9 +174,15 @@ async def tool_entries() -> list[dict[str, str]]:
             # of them came from.
             "DELTA_MCP_AUDIT": "off",
         })
+        from delta_exchange_mcp import debug_log
         from delta_exchange_mcp.server import build_server
 
-        tools = await build_server().list_tools()
+        try:
+            tools = await build_server().list_tools()
+        finally:
+            # Debug is intentionally on for manifest introspection. Its FileHandler points
+            # inside scratch and must be closed before TemporaryDirectory removes it.
+            debug_log.shutdown()
 
     return [
         {

--- a/packaging/mcpb/make_bundle.py
+++ b/packaging/mcpb/make_bundle.py
@@ -154,25 +154,30 @@ async def tool_entries() -> list[dict[str, str]]:
     """
     for name in [name for name in os.environ if name.startswith("DELTA_")]:
         del os.environ[name]
-    os.environ.update({
-        "DELTA_MCP_MODE": "trade",
-        "DELTA_MCP_ENV": "india_prod",
-        "DELTA_MCP_DEBUG": "1",
-        # Both logs are redirected into a throwaway directory. Introspecting a tool list
-        # produces nothing worth keeping, and left at their defaults each manifest build
-        # dropped another file into ~/.delta-exchange-mcp/.
-        "DELTA_MCP_DEBUG_FILE": str(pathlib.Path(tempfile.mkdtemp()) / "debug.log"),
-        "DELTA_API_KEY": "placeholder",
-        "DELTA_API_SECRET": "placeholder",
-        # Trade mode plus credentials is what opens the audit log, and listing tool names
-        # mutates nothing worth auditing. Left on, every manifest build dropped another
-        # empty file into ~/.delta-exchange-mcp/audit/, which is where 4,493 of them
-        # came from.
-        "DELTA_MCP_AUDIT": "off",
-    })
-    from delta_exchange_mcp.server import build_server
 
-    tools = await build_server().list_tools()
+    # Scratch directory rather than a bare mkdtemp, because turning debug on means the
+    # server opens a log file and nothing here wants to keep it. A bare mkdtemp is not
+    # removed by anyone, so every build would leave a directory and a log behind for the
+    # operating system to reap eventually — trading files left in the home directory for
+    # files left in /tmp, which is not the fix it looks like.
+    with tempfile.TemporaryDirectory(prefix="mcpb-manifest-") as scratch:
+        os.environ.update({
+            "DELTA_MCP_MODE": "trade",
+            "DELTA_MCP_ENV": "india_prod",
+            "DELTA_MCP_DEBUG": "1",
+            "DELTA_MCP_DEBUG_FILE": str(pathlib.Path(scratch) / "debug.log"),
+            "DELTA_API_KEY": "placeholder",
+            "DELTA_API_SECRET": "placeholder",
+            # Trade mode plus credentials is what opens the audit log, and listing tool
+            # names mutates nothing worth auditing. Left on, every manifest build dropped
+            # another empty file into ~/.delta-exchange-mcp/audit/, which is where 4,493
+            # of them came from.
+            "DELTA_MCP_AUDIT": "off",
+        })
+        from delta_exchange_mcp.server import build_server
+
+        tools = await build_server().list_tools()
+
     return [
         {
             "name": t.name,

--- a/packaging/mcpb/make_bundle.py
+++ b/packaging/mcpb/make_bundle.py
@@ -12,6 +12,7 @@ import json
 import os
 import pathlib
 import sys
+import tempfile
 import tomllib
 
 HERE = pathlib.Path(__file__).resolve().parent
@@ -131,21 +132,36 @@ async def tool_entries() -> list[dict[str, str]]:
 
     Every DELTA_ variable is cleared before the ones that matter are set, so the manifest
     depends only on the source being packaged and never on the shell the build ran in.
-    Forcing a named few was not enough. A developer with DELTA_MCP_DEBUG=1 exported got
-    `get_debug_status` written into the manifest — 42 tools instead of 41 — and CI, whose
-    shell has no such variable, then rejects that manifest as stale. DELTA_MCP_ENV leaked
-    the same way, where an invalid value in the shell failed the build inside `load()`.
+    Forcing a named few was not enough: a developer with DELTA_MCP_DEBUG=1 exported got a
+    different manifest than CI produced, and CI then rejected it as stale. DELTA_MCP_ENV
+    leaked the same way, where an invalid value in the shell failed the build inside `load()`.
 
-    Trade mode is forced because the declared list has to be the *superset*. `tools_generated`
-    is false, which promises the runtime never exposes anything beyond this list, and a user
-    who sets Mode to trade reaches all of it. Listing only the read surface would break that
-    promise the moment someone opted in.
+    Every optional surface is then forced ON, because the declared list has to be the
+    *superset*. `tools_generated` is false, which promises the runtime never exposes anything
+    beyond this list, so anything a user can switch on has to already be in it:
+
+    * Trade mode, reached through the install form's Mode field.
+    * Debug, which registers `get_debug_status`. Nothing in the manifest declares
+      DELTA_MCP_DEBUG, and the manifest env is applied *over* the user's environment, so an
+      exported DELTA_MCP_DEBUG=1 reaches an installed bundle untouched — measured: 28 tools
+      registered against 41 declared, with `get_debug_status` among neither.
+
+    Declaring DELTA_MCP_DEBUG="" in the manifest would also stop that, but it would take
+    away the only way a bundle user can turn debug logging on at all — and that log is how
+    they capture wire-level evidence for a bug report, since a bundle has no config file to
+    edit. Listing the tool costs nothing by comparison: `tools_generated: false` promises a
+    ceiling, not an exact set, which is already how the 13 mutating tools are handled.
     """
     for name in [name for name in os.environ if name.startswith("DELTA_")]:
         del os.environ[name]
     os.environ.update({
         "DELTA_MCP_MODE": "trade",
         "DELTA_MCP_ENV": "india_prod",
+        "DELTA_MCP_DEBUG": "1",
+        # Both logs are redirected into a throwaway directory. Introspecting a tool list
+        # produces nothing worth keeping, and left at their defaults each manifest build
+        # dropped another file into ~/.delta-exchange-mcp/.
+        "DELTA_MCP_DEBUG_FILE": str(pathlib.Path(tempfile.mkdtemp()) / "debug.log"),
         "DELTA_API_KEY": "placeholder",
         "DELTA_API_SECRET": "placeholder",
         # Trade mode plus credentials is what opens the audit log, and listing tool names

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "delta-exchange-mcp",
   "display_name": "Delta Exchange",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Live market data and your Delta Exchange India account.",
   "long_description": "Ask about Delta Exchange India in plain English: live prices, option chains, order books, funding and open-interest history, plus your own positions, orders, fills and balances.\n\n**Read-only unless you change Mode.** Left at `read`, this cannot place, change or cancel orders, and can never move funds. Set Mode to `trade` and it can place, edit and cancel real orders on the environment you selected \u2014 there is no size limit, and orders are sized in contracts rather than coins. Every mutation is written to an audit log under `~/.delta-exchange-mcp/audit/`. Leave this at `read` unless you specifically want an assistant trading your account.\n\n**Both credential fields or neither.** A key without its matching secret is ignored and you get market data only \u2014 the two are always used together. Trading additionally needs a key with trading permission, not just Read Data.\n\n**Market data needs no setup** \u2014 leave the API key and secret empty and everything except your own account still works.\n\n**To see your account**, create a key at delta.exchange under Account \u2192 API Keys with the **Read Data** permission. Both halves are shown only once, at creation. Paste them into Configure. Your key is stored by this app and is sent only to Delta's API, from your own machine.\n\n**Environment** must be `india_prod` for the real exchange, or `india_testnet` for the practice site at demo.delta.exchange. A key only works against the site it was made on.",
   "author": {

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -92,6 +92,10 @@
       "description": "OHLC candles. For funding/mark/OI history prefer the dedicated tools"
     },
     {
+      "name": "get_debug_status",
+      "description": "Whether debug logging is on and the absolute path of the current log file."
+    },
+    {
       "name": "get_fills",
       "description": "Your trade fills (executed trades). Paginated. Timestamps are microseconds."
     },

--- a/packaging/mcpb/verify.py
+++ b/packaging/mcpb/verify.py
@@ -19,15 +19,7 @@ import time
 import zipfile
 from pathlib import Path
 
-MUTATION_PREFIXES = (
-    "place_",
-    "cancel_",
-    "edit_",
-    "close_",
-    "adjust_",
-    "set_product",
-    "configure_",
-)
+MUTATING_TOOL_META_KEY = "delta.exchange/mutating"
 
 
 def check_archive(mcpb: Path) -> None:
@@ -135,8 +127,8 @@ def _pump(stream, put) -> None:
 
 def handshake(
     extracted: Path, env: dict[str, str] | None = None, timeout: float = 240.0
-) -> list[str]:
-    """Start the unpacked server over stdio and return the tool names it registers."""
+) -> dict[str, dict]:
+    """Start the unpacked server over stdio and return the tools it registers by name."""
     proc = subprocess.Popen(
         ["uv", "run", "--directory", str(extracted), "--frozen", "python", "server/main.py"],
         stdin=subprocess.PIPE,
@@ -217,7 +209,16 @@ def handshake(
 
     info = seen[1]["result"].get("serverInfo", {})
     print(f"  handshake: initialize OK, serverInfo={info}")
-    return sorted(t["name"] for t in seen[2]["result"]["tools"])
+    return {tool["name"]: tool for tool in seen[2]["result"]["tools"]}
+
+
+def mutation_names(tools: dict[str, dict]) -> list[str]:
+    """Return tools whose registration explicitly identifies them as mutating."""
+    return sorted(
+        name
+        for name, tool in tools.items()
+        if tool.get("_meta", {}).get(MUTATING_TOOL_META_KEY) is True
+    )
 
 
 def main() -> None:
@@ -236,7 +237,7 @@ def main() -> None:
         default = handshake(
             tmp, launch_env(manifest, manifest["user_config"]["mode"]["default"], tmp)
         )
-        leaked = [n for n in default if n.startswith(MUTATION_PREFIXES)]
+        leaked = mutation_names(default)
         print(f"  default mode: {len(default)} tools, {len(leaked)} mutating")
         if leaked:
             raise SystemExit(
@@ -248,7 +249,7 @@ def main() -> None:
 
         # And the opt-in has to actually reach trading, or the field is decorative.
         opted = handshake(tmp, launch_env(manifest, "trade", tmp))
-        mutating = [n for n in opted if n.startswith(MUTATION_PREFIXES)]
+        mutating = mutation_names(opted)
         print(f"  mode=trade:   {len(opted)} tools, {len(mutating)} mutating")
         if not mutating:
             raise SystemExit("opting into trade registered no mutation tools")

--- a/packaging/mcpb/verify.py
+++ b/packaging/mcpb/verify.py
@@ -77,7 +77,7 @@ def check_archive(mcpb: Path) -> None:
     print(f"  payload: {', '.join(sorted(required))}, {wheels.pop()}")
 
 
-def launch_env(manifest: dict, mode: str) -> dict[str, str]:
+def launch_env(manifest: dict, mode: str, workdir: Path) -> dict[str, str]:
     """The environment a host would build, over a deliberately hostile one.
 
     The ambient half sets DELTA_MCP_MODE=trade and supplies credentials, which is what a
@@ -85,6 +85,17 @@ def launch_env(manifest: dict, mode: str) -> dict[str, str]:
     ${user_config.x} resolved the way the host resolves it. Checking the result is what
     makes "the form decides the mode, not the environment" an actual test rather than an
     assertion that passes because no credentials were present.
+
+    DELTA_MCP_DEBUG is in the ambient half and *not* declared by the manifest, which is the
+    point: the manifest env is applied over the user's environment, so an undeclared variable
+    reaches the server untouched and registers `get_debug_status`. Left out of here, the
+    undeclared-tool check in `main` could only ever pass, because CI's own shell has no such
+    variable. With it, that check is what proves the declared list is a real ceiling.
+
+    Turning debug on means the server writes a log, and trade mode with credentials opens an
+    audit log, so both are pointed at `workdir` — the throwaway unpack. Left at their
+    defaults, every build dropped two debug logs and an audit file into the developer's
+    ~/.delta-exchange-mcp, which is not somewhere a build should be writing at all.
     """
     config = {k: v.get("default", "") for k, v in manifest["user_config"].items()}
     config.update({"mode": mode, "api_key": "placeholder", "api_secret": "placeholder"})
@@ -94,6 +105,9 @@ def launch_env(manifest: dict, mode: str) -> dict[str, str]:
         "DELTA_MCP_MODE": "trade",
         "DELTA_API_KEY": "ambient",
         "DELTA_API_SECRET": "ambient",
+        "DELTA_MCP_DEBUG": "1",
+        "DELTA_MCP_DEBUG_FILE": str(workdir / "debug.log"),
+        "DELTA_MCP_AUDIT_FILE": str(workdir / "audit.log"),
     })
     for key, raw in manifest["server"]["mcp_config"]["env"].items():
         env[key] = re.sub(
@@ -219,7 +233,9 @@ def main() -> None:
 
         # Someone who accepted the form's defaults, on a machine whose environment is
         # already asking for trade mode. The declared default has to win.
-        default = handshake(tmp, launch_env(manifest, manifest["user_config"]["mode"]["default"]))
+        default = handshake(
+            tmp, launch_env(manifest, manifest["user_config"]["mode"]["default"], tmp)
+        )
         leaked = [n for n in default if n.startswith(MUTATION_PREFIXES)]
         print(f"  default mode: {len(default)} tools, {len(leaked)} mutating")
         if leaked:
@@ -231,15 +247,18 @@ def main() -> None:
             raise SystemExit("no tools registered")
 
         # And the opt-in has to actually reach trading, or the field is decorative.
-        opted = handshake(tmp, launch_env(manifest, "trade"))
+        opted = handshake(tmp, launch_env(manifest, "trade", tmp))
         mutating = [n for n in opted if n.startswith(MUTATION_PREFIXES)]
         print(f"  mode=trade:   {len(opted)} tools, {len(mutating)} mutating")
         if not mutating:
             raise SystemExit("opting into trade registered no mutation tools")
 
         # tools_generated is false, which promises the manifest lists everything reachable.
+        # Both runs, not just the trade one: an undeclared tool that a variable in the user's
+        # own environment switches on appears in the default install too, and that is the
+        # install almost everyone has.
         declared = {t["name"] for t in manifest["tools"]}
-        undeclared = set(opted) - declared
+        undeclared = (set(default) | set(opted)) - declared
         if undeclared:
             raise SystemExit(
                 "manifest declares tools_generated=false but the server registers "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "delta-exchange-mcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "Official MCP server for Delta Exchange India — market data and account read for AI assistants."
 readme = "README.md"
 license = "MIT"

--- a/src/delta_exchange_mcp/debug_log.py
+++ b/src/delta_exchange_mcp/debug_log.py
@@ -91,3 +91,19 @@ def configure(cfg: Config) -> Path | None:
         PACKAGE_VERSION, cfg.env, cfg.base_url, surface,
     )
     return path
+
+
+def shutdown() -> None:
+    """Detach and close the debug handler attached by this module, if any."""
+    handlers: set[logging.Handler] = set()
+    for name in LOGGER_NAMES:
+        logger = logging.getLogger(name)
+        for handler in list(logger.handlers):
+            if getattr(handler, _MARKER, False):
+                logger.removeHandler(handler)
+                handlers.add(handler)
+
+    # The same handler is attached to both module loggers. Close it only after it has been
+    # detached everywhere, and only once, so Windows can remove its containing directory.
+    for handler in handlers:
+        handler.close()

--- a/src/delta_exchange_mcp/tools/trading.py
+++ b/src/delta_exchange_mcp/tools/trading.py
@@ -23,6 +23,8 @@ logger = logging.getLogger("delta_exchange_mcp")
 
 _MAX_BATCH = 50
 _STOP_TRIGGER_METHODS = "mark_price, last_traded_price, spot_price"
+MUTATING_TOOL_META_KEY = "delta.exchange/mutating"
+_MUTATING_TOOL_META = {MUTATING_TOOL_META_KEY: True}
 
 
 def _bs(value: bool | None) -> str | None:
@@ -130,6 +132,7 @@ def _round_to_tick(price: str, tick: Decimal) -> tuple[str, bool]:
 
 
 def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -> None:
+    mutation_tool = mcp.tool(meta=_MUTATING_TOOL_META)
     _uid_cache: dict[str, int] = {}
     # tick_size keyed by both product id (int) and symbol (str); filled lazily.
     _tick_cache: dict[int | str, Decimal] = {}
@@ -237,7 +240,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
 
     # ---------------------------------------------------------------- single order
 
-    @mcp.tool()
+    @mutation_tool
     async def place_order(
         size: int = Field(description="Order size in contracts."),
         side: str = Field(description="buy or sell."),
@@ -309,7 +312,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         result = await _finish("place_order", "POST", "/orders", payload, dry_run=dry_run)
         return _attach(result, adjustments)
 
-    @mcp.tool()
+    @mutation_tool
     async def edit_order(
         id: int = Field(description="Order id to edit."),
         size: int = Field(description="Total size after the edit."),
@@ -342,7 +345,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         result = await _finish("edit_order", "PUT", "/orders", payload, dry_run=dry_run)
         return _attach(result, adjustments)
 
-    @mcp.tool()
+    @mutation_tool
     async def cancel_order(
         product_id: int = Field(description="Product id the order belongs to."),
         id: int | None = Field(default=None, description="Order id to cancel."),
@@ -355,7 +358,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         payload = {"product_id": product_id, "id": id, "client_order_id": client_order_id}
         return await _finish("cancel_order", "DELETE", "/orders", payload, dry_run=dry_run)
 
-    @mcp.tool()
+    @mutation_tool
     async def cancel_all_orders(
         product_id: int | None = Field(default=None, description="Limit to one product."),
         contract_types: list[str] | None = Field(
@@ -398,7 +401,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
             raise ValueError(f"batch size {len(orders)} exceeds max {_MAX_BATCH}")
         return [_clean(o) for o in orders]
 
-    @mcp.tool()
+    @mutation_tool
     async def place_batch_orders(
         orders: list[dict[str, Any]] = Field(
             description="Up to 50 orders, each {size, side, order_type, limit_price?, "
@@ -431,7 +434,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         result = await _finish("place_batch_orders", "POST", "/orders/batch", payload, dry_run=dry_run)
         return _flag_partial(result, cleaned)
 
-    @mcp.tool()
+    @mutation_tool
     async def edit_batch_orders(
         orders: list[dict[str, Any]] = Field(
             description="Up to 50 edits, each {id, size, order_type, limit_price?, post_only?}."
@@ -453,7 +456,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         result = await _finish("edit_batch_orders", "PUT", "/orders/batch", payload, dry_run=dry_run)
         return _flag_partial(result, cleaned)
 
-    @mcp.tool()
+    @mutation_tool
     async def cancel_batch_orders(
         orders: list[dict[str, Any]] = Field(
             description="Up to 50 orders to cancel, each {id} or {client_order_id}."
@@ -475,7 +478,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
 
     # ---------------------------------------------------------------- bracket orders
 
-    @mcp.tool()
+    @mutation_tool
     async def place_bracket_order(
         product_id: int | None = Field(default=None, description="Product id (or pass product_symbol)."),
         product_symbol: str | None = Field(default=None, description="e.g. BTCUSD (or pass product_id)."),
@@ -519,7 +522,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         result = await _finish("place_bracket_order", "POST", "/orders/bracket", payload, dry_run=dry_run)
         return _attach(result, adjustments)
 
-    @mcp.tool()
+    @mutation_tool
     async def edit_bracket_order(
         id: int = Field(description="Order id whose bracket params to update."),
         product_id: int | None = Field(default=None, description="Product id (or pass product_symbol)."),
@@ -564,7 +567,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
 
     # ---------------------------------------------------------------- positions & leverage
 
-    @mcp.tool()
+    @mutation_tool
     async def set_product_leverage(
         product_id: int = Field(description="Product id to set order leverage for."),
         leverage: str = Field(description="Leverage multiplier, e.g. '10'."),
@@ -576,7 +579,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
             f"/products/{product_id}/orders/leverage", {"leverage": leverage}, dry_run=dry_run,
         )
 
-    @mcp.tool()
+    @mutation_tool
     async def adjust_position_margin(
         product_id: int = Field(description="Product id of the position."),
         delta_margin: str = Field(description="Margin to add (positive) or remove (negative), e.g. '5.0'."),
@@ -588,7 +591,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
             "adjust_position_margin", "POST", "/positions/change_margin", payload, dry_run=dry_run
         )
 
-    @mcp.tool()
+    @mutation_tool
     async def close_all_positions(
         close_all_portfolio: bool = Field(default=False, description="Close cross/portfolio-margined positions."),
         close_all_isolated: bool = Field(default=False, description="Close isolated-margin positions."),
@@ -609,7 +612,7 @@ def register(mcp: FastMCP, client: DeltaClient, audit: AuditLog | None = None) -
         }
         return await _finish("close_all_positions", "POST", "/positions/close_all", payload, dry_run=dry_run)
 
-    @mcp.tool()
+    @mutation_tool
     async def configure_auto_topup(
         product_id: int = Field(description="Product id of the position."),
         auto_topup: bool = Field(description="Enable or disable auto top-up for this position."),

--- a/tests/test_debug_log.py
+++ b/tests/test_debug_log.py
@@ -14,11 +14,9 @@ def _clear_handlers():
     """Each test attaches a FileHandler to module loggers; remove them after so the open
     file doesn't leak into the next test (and the idempotency guard starts fresh)."""
     yield
+    debug_log.shutdown()
     for name in debug_log.LOGGER_NAMES:
         logger = logging.getLogger(name)
-        for h in list(logger.handlers):
-            h.close()
-            logger.removeHandler(h)
         logger.setLevel(logging.NOTSET)
         logger.propagate = True
 
@@ -88,6 +86,21 @@ def test_debug_off_returns_none(tmp_path, monkeypatch):
     monkeypatch.setenv("DELTA_MCP_DEBUG_FILE", str(tmp_path / "d.log"))
     assert debug_log.configure(_cfg(tmp_path, debug=False)) is None
     assert not (tmp_path / "d.log").exists()
+
+
+def test_shutdown_detaches_and_closes_shared_handler(tmp_path, monkeypatch):
+    monkeypatch.setenv("DELTA_MCP_DEBUG_FILE", str(tmp_path / "d.log"))
+    debug_log.configure(_cfg(tmp_path, debug=True))
+
+    handler = logging.getLogger("delta_exchange_mcp").handlers[0]
+    assert all(handler in logging.getLogger(name).handlers for name in debug_log.LOGGER_NAMES)
+    assert handler.stream is not None
+
+    debug_log.shutdown()
+
+    assert all(handler not in logging.getLogger(name).handlers for name in debug_log.LOGGER_NAMES)
+    assert handler.stream is None
+    debug_log.shutdown()  # idempotent
 
 
 def test_log_file_is_owner_only(tmp_path, monkeypatch):

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -268,6 +268,23 @@ def test_trade_tools_present_in_trade_mode(monkeypatch):
         assert tool in names
 
 
+@pytest.mark.asyncio
+async def test_all_trading_tools_declare_mutating_metadata():
+    mcp = FastMCP("test")
+    client = _client()
+    try:
+        trading.register(mcp, client)
+        tools = await mcp.list_tools()
+    finally:
+        await client.aclose()
+
+    assert len(tools) == 13
+    assert all(
+        tool.meta == {trading.MUTATING_TOOL_META_KEY: True}
+        for tool in tools
+    )
+
+
 # --------------------------------------------------------------- BUG-1: cancel_all defaults
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "delta-exchange-mcp"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Why

Promote the post-v0.5.0 fixes currently merged on `develop`:

- #54 closes the MCPB `tools_generated: false` ceiling by declaring the debug-only tool, exercises a deliberately hostile ambient debug/trade environment, checks both runtime surfaces for undeclared tools, and keeps generated logs in a scoped temporary directory.
- #55 makes the primary Claude Desktop badge download the stable-name bundle asset directly.
- `0d355e5` closes the release-verification gaps raised in self-review: the 13 trading tools now declare themselves mutating through a `delta.exchange/mutating` meta key, so the verifier identifies them by declaration instead of inference; the bundle workflow also runs on pushes to `develop`; and `ruff` now covers `packaging/`.

## Change set

- Generated MCPB manifest: 42 declared tools, including `get_debug_status`, at version `0.5.1`.
- Bundle verifier: default 28 tools / 0 mutating; trade 42 tools / 13 mutating; undeclared-tool checks cover both surfaces.
- README: one-click Claude Desktop CTA now targets `/releases/latest/download/delta-exchange-mcp.mcpb`.
- Tree delta from `main`: 15 files, 202 insertions, 86 deletions.

## Verification already completed on develop

- Ruff passed, now including `packaging/`.
- 126 tests passed on Python 3.12.
- 126 tests passed on Python 3.13.
- Bundle build, strict archive checks, real MCP handshakes, manifest regeneration, and Greptile review passed on #54.
- The stable-name download URL currently returns the published 97,889-byte v0.5.0 asset, and will resolve to v0.5.1 once this release is cut.

## Release state

The release gate is met. Source, generated manifest, and `uv.lock` all identify themselves as `0.5.1`, the self-review findings are addressed, and Greptile has reviewed the current head at 5/5 with no open threads.

What remains is process rather than code: a team approval on this PR, and the announce-first step — post the going-live ticket list in the service channel and get the QA and product go-ahead before merging.
