### PR TITLE
Release v0.6.0

### DIFF
--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "delta-exchange-mcp",
   "display_name": "Delta Exchange",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Live market data and your Delta Exchange India account.",
   "long_description": "Ask about Delta Exchange India in plain English: live prices, option chains, order books, funding and open-interest history, plus your own positions, orders, fills and balances.\n\n**Read-only unless you change Mode.** Left at `read`, this cannot place, change or cancel orders, and can never move funds. Set Mode to `trade` and it can place, edit and cancel real orders on the environment you selected \u2014 there is no size limit, and orders are sized in contracts rather than coins. Every mutation is written to an audit log under `~/.delta-exchange-mcp/audit/`. Leave this at `read` unless you specifically want an assistant trading your account.\n\n**Both credential fields or neither.** A key without its matching secret is ignored and you get market data only \u2014 the two are always used together. Trading additionally needs a key with trading permission, not just Read Data.\n\n**Market data needs no setup** \u2014 leave the API key and secret empty and everything except your own account still works.\n\n**To see your account**, create a key at delta.exchange under Account \u2192 API Keys with the **Read Data** permission. Both halves are shown only once, at creation. Paste them into Configure. Your key is stored by this app and is sent only to Delta's API, from your own machine.\n\n**Environment** must be `india_prod` for the real exchange, or `india_testnet` for the practice site at demo.delta.exchange. A key only works against the site it was made on.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "delta-exchange-mcp"
-version = "0.5.1"
+version = "0.6.0"
 description = "Official MCP server for Delta Exchange India — market data and account read for AI assistants."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "delta-exchange-mcp"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Version bump only, ahead of the `develop -> main` release PR.

`develop` and `main` both still read `0.5.1`, the version staged by #58 but never published — there is no `v0.5.1` tag, no GitHub release, and PyPI still serves `0.5.0`. Since that version was staged, #51 and #52 landed on `develop` and changed what a release would contain, so the number has to move before anything ships.

`0.6.0` rather than `0.5.2` because RELEASING.md reserves minor bumps for "new tools, env variables, or behavior changes" and this round is all three: `get_connection_status`, `setup_credentials`, `save_credentials` and `get_debug_status` are new tools, `DELTA_MCP_MODE_<CLIENT>` is a new variable, credentials now resolve from a shared file, and the `mcp` floor moves from `>=1.12.4` to `>=1.26.0`.

## Changed

- `pyproject.toml` — `0.5.1` to `0.6.0`
- `uv.lock` — refreshed by `uv sync`
- `packaging/mcpb/manifest.json` — regenerated by `packaging/mcpb/build.sh`, which the Bundle workflow enforces with `git diff --exit-code`; a bump with a stale manifest turns that check red

Nothing else. The manifest diff is the version field alone.

## Verified

- `uv run ruff check src tests scripts packaging` — clean
- `uv run pytest` — 259 passed
- `bash packaging/mcpb/build.sh` — bundle builds and verifies against the packed artifact: `serverInfo` reports `0.6.0`, default mode registers 32 tools with 0 mutating, `mode=trade` registers 46 with 13