### PR TITLE
Add bounded client and tool analytics with a process opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,27 @@ stay absent.
 - **Local stdio only.** Per-user keys never leave your machine; no shared hosted endpoint.
 - **Read the code.** It's a financial-tool MCP; treat it like one.
 
+## API request analytics
+
+Delta API requests carry a small set of headers that identify the MCP client and tool that
+caused the request. Delta uses these headers to measure client and tool usage. The client
+name is self-reported. It is an analytics label and never authorizes account access or
+trading.
+
+| Header | Value |
+|---|---|
+| `X-Delta-MCP-Version` | This server's version. |
+| `X-Delta-MCP-Client` | The exact name reported by the MCP client, when available. |
+| `X-Delta-MCP-Client-Version` | The version reported by the MCP client, when available. |
+| `X-Delta-MCP-Tool` | The MCP tool that caused the Delta request. |
+| `X-Delta-MCP-Protocol` | The MCP protocol version for the request. |
+| `X-Delta-MCP-Context` | The client's optional title, description, website, icon count, and capability shape, plus the operating system and Python version. Private extension names and settings are not included. |
+
+The server does not add the Delta environment, trading state, credential source, consent
+state, credential or consent revision, account ID, API key, API secret, signature, or a
+credential digest to these headers. It also adds no connection or installation identifier.
+Untrusted text is encoded, and the complete analytics header set is limited to 4,096 bytes.
+
 ## Updating
 
 `uvx` caches the resolved package, so a new PyPI release isn't picked up automatically. To move to the latest version:

--- a/README.md
+++ b/README.md
@@ -541,8 +541,8 @@ stay absent.
 
 Delta API requests carry a small set of headers that identify the MCP client and tool that
 caused the request. Delta uses these headers to measure client and tool usage. The client
-name is self-reported. It is an analytics label and never authorizes account access or
-trading.
+name is self-reported. The authorization layer uses its exact value to partition consent
+records, but the name is not proof of identity and cannot grant consent by itself.
 
 | Header | Value |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ non-secret settings only. Process settings take precedence over values in that f
 | `DELTA_MCP_DEBUG_FILE` | automatic | Override the debug log path. |
 | `DELTA_MCP_AUDIT` | on for mutations | Set `off`, `false`, `0`, or `no` to disable the trading audit log. |
 | `DELTA_MCP_AUDIT_FILE` | automatic | Override the audit log path. |
+| `DELTA_MCP_ANALYTICS` | on | Set `off`, `false`, `0`, or `no` in the MCP client's process environment to omit all `X-Delta-MCP-*` headers. |
 | `DELTA_MCP_CONFIG_FILE` | `~/.delta-exchange-mcp/config.env` | Move the non-secret shared settings file. |
 
 ## Install in your MCP client
@@ -427,12 +428,21 @@ records, but the name is not proof of identity and cannot grant consent by itsel
 | `X-Delta-MCP-Client-Version` | The version reported by the MCP client, when available. |
 | `X-Delta-MCP-Tool` | The MCP tool that caused the Delta request. |
 | `X-Delta-MCP-Protocol` | The MCP protocol version for the request. |
-| `X-Delta-MCP-Context` | The client's optional title, description, website, icon count, and capability shape, plus the operating system and Python version. Private extension names and settings are not included. |
+| `X-Delta-MCP-Context` | The operating system and architecture, Python major and minor version, presence of sampling, elicitation, roots and tasks, and counts of experimental and extension capabilities. Private extension names and settings are not included. |
 
 The server does not add the Delta environment, trading state, credential source, consent
 state, credential or consent revision, account ID, API key, API secret, signature, or a
 credential digest to these headers. It also adds no connection or installation identifier.
 Untrusted text is encoded, and the complete analytics header set is limited to 4,096 bytes.
+The server does not forward the client's title, description, website, or icons. Client
+names and versions are still supplied by the client. Do not put personal information in
+these fields.
+
+Set `DELTA_MCP_ANALYTICS=off` in the MCP client's process environment to omit all six
+analytics headers. The required User-Agent and authentication headers still apply.
+The package does not store an analytics history locally. Delta API infrastructure receives
+the headers with each request. Its log retention is controlled outside this package;
+this repository does not define or promise a retention period for those logs.
 
 ## Updating
 

--- a/src/delta_exchange_mcp/analytics.py
+++ b/src/delta_exchange_mcp/analytics.py
@@ -26,7 +26,7 @@ CONTEXT_HEADER = f"{PREFIX}Context"
 BUDGET_BYTES = 4096
 FIELD_LIMIT = 200
 
-_SAFE = " !\"#$&'()*+,-./:;<=>?@[]^_`{|}~"
+_SAFE = "!\"#$&'()*+,-./:;<=>?@[]^_`{|}~"
 _CLOSED_CAPABILITIES = ("sampling", "elicitation", "roots", "tasks")
 _OPEN_CAPABILITIES = ("experimental", "extensions")
 _PLATFORM = f"{platform.system()} {platform.machine()}"

--- a/src/delta_exchange_mcp/analytics.py
+++ b/src/delta_exchange_mcp/analytics.py
@@ -18,6 +18,7 @@ from mcp_types import (
 )
 from mcp_types.version import MODERN_PROTOCOL_VERSIONS
 
+from delta_exchange_mcp import request
 from delta_exchange_mcp.version import PACKAGE_VERSION
 
 PREFIX = "X-Delta-MCP-"
@@ -137,14 +138,15 @@ def _legacy_models(
 
 
 def _snapshot(ctx: Context, tool: str) -> _Call:
+    reported = request.context_client(ctx)
     if ctx.protocol_version in MODERN_PROTOCOL_VERSIONS:
         info, capabilities = _modern_models(ctx)
     else:
         info, capabilities = _legacy_models(ctx)
     return _Call(
-        client_name=info.name if info is not None else "",
-        client_version=info.version if info is not None else "",
-        title=(info.title or "")[:FIELD_LIMIT] if info is not None else "",
+        client_name=reported.name,
+        client_version=reported.version,
+        title=reported.title[:FIELD_LIMIT],
         description=(info.description or "")[:FIELD_LIMIT] if info is not None else "",
         website_url=(info.website_url or "")[:FIELD_LIMIT] if info is not None else "",
         icon_count=len(info.icons or ()) if info is not None else 0,

--- a/src/delta_exchange_mcp/analytics.py
+++ b/src/delta_exchange_mcp/analytics.py
@@ -107,19 +107,11 @@ def _modern_models(
     raw_info = meta.get(CLIENT_INFO_META_KEY)
     raw_capabilities = meta.get(CLIENT_CAPABILITIES_META_KEY)
     try:
-        info = (
-            raw_info
-            if isinstance(raw_info, Implementation)
-            else Implementation.model_validate(raw_info)
-        )
+        info = Implementation.model_validate(raw_info)
     except (TypeError, ValueError):
         info = None
     try:
-        capabilities = (
-            raw_capabilities
-            if isinstance(raw_capabilities, ClientCapabilities)
-            else ClientCapabilities.model_validate(raw_capabilities)
-        )
+        capabilities = ClientCapabilities.model_validate(raw_capabilities)
     except (TypeError, ValueError):
         capabilities = None
     return info, capabilities

--- a/src/delta_exchange_mcp/analytics.py
+++ b/src/delta_exchange_mcp/analytics.py
@@ -1,0 +1,204 @@
+"""Bounded analytics headers for outbound Delta API requests."""
+
+import json
+import platform
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from urllib.parse import quote
+
+from mcp.server.mcpserver import Context
+from mcp_types import (
+    CLIENT_CAPABILITIES_META_KEY,
+    CLIENT_INFO_META_KEY,
+    ClientCapabilities,
+    Implementation,
+)
+from mcp_types.version import MODERN_PROTOCOL_VERSIONS
+
+from delta_exchange_mcp.version import PACKAGE_VERSION
+
+PREFIX = "X-Delta-MCP-"
+CONTEXT_HEADER = f"{PREFIX}Context"
+BUDGET_BYTES = 4096
+FIELD_LIMIT = 200
+
+_SAFE = " !\"#$&'()*+,-./:;<=>?@[]^_`{|}~"
+_CLOSED_CAPABILITIES = ("sampling", "elicitation", "roots", "tasks")
+_OPEN_CAPABILITIES = ("experimental", "extensions")
+_PLATFORM = f"{platform.system()} {platform.machine()}"
+_PYTHON = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+
+@dataclass(frozen=True)
+class _Call:
+    """The non-sensitive analytics fields copied from one MCP tool request."""
+
+    client_name: str = ""
+    client_version: str = ""
+    title: str = ""
+    description: str = ""
+    website_url: str = ""
+    icon_count: int = 0
+    capabilities: tuple[tuple[str, bool | int], ...] = ()
+    tool: str = ""
+    protocol: str = ""
+
+
+_current: ContextVar[_Call | None] = ContextVar("delta_analytics_call", default=None)
+
+
+def encode(value: str) -> str:
+    """Encode an untrusted string as printable ASCII for an HTTP header."""
+    return quote(value, safe=_SAFE, errors="replace")
+
+
+def clean(value: str) -> str:
+    """Encode and bound one discrete header value."""
+    encoded = encode(value)
+    if len(encoded) <= FIELD_LIMIT:
+        return encoded
+    cut = encoded[:FIELD_LIMIT]
+    if "%" in cut[-2:]:
+        cut = cut[: cut.rfind("%")]
+    return cut
+
+
+def as_header(payload: dict[str, object]) -> str:
+    """Serialize a context object as safe, directly parseable JSON."""
+    value = json.dumps(
+        payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    if value.isascii() and value.isprintable():
+        return value
+    return ""
+
+
+def _capabilities(capabilities: ClientCapabilities | None) -> dict[str, bool | int]:
+    """Project capabilities without forwarding extension names or settings."""
+    if capabilities is None:
+        return {}
+    result: dict[str, bool | int] = {}
+    for name in _CLOSED_CAPABILITIES:
+        if getattr(capabilities, name, None) is not None:
+            result[name] = True
+    for name in _OPEN_CAPABILITIES:
+        if declared := getattr(capabilities, name, None):
+            result[name] = len(declared)
+    return result
+
+
+def _modern_models(
+    ctx: Context,
+) -> tuple[Implementation | None, ClientCapabilities | None]:
+    try:
+        meta = ctx.request_context.meta
+    except ValueError:
+        return None, None
+    if meta is None:
+        return None, None
+
+    raw_info = meta.get(CLIENT_INFO_META_KEY)
+    raw_capabilities = meta.get(CLIENT_CAPABILITIES_META_KEY)
+    try:
+        info = (
+            raw_info
+            if isinstance(raw_info, Implementation)
+            else Implementation.model_validate(raw_info)
+        )
+    except (TypeError, ValueError):
+        info = None
+    try:
+        capabilities = (
+            raw_capabilities
+            if isinstance(raw_capabilities, ClientCapabilities)
+            else ClientCapabilities.model_validate(raw_capabilities)
+        )
+    except (TypeError, ValueError):
+        capabilities = None
+    return info, capabilities
+
+
+def _legacy_models(
+    ctx: Context,
+) -> tuple[Implementation | None, ClientCapabilities | None]:
+    try:
+        params = ctx.session.client_params
+    except ValueError:
+        return None, None
+    if params is None:
+        return None, None
+    return params.client_info, params.capabilities
+
+
+def _snapshot(ctx: Context, tool: str) -> _Call:
+    if ctx.protocol_version in MODERN_PROTOCOL_VERSIONS:
+        info, capabilities = _modern_models(ctx)
+    else:
+        info, capabilities = _legacy_models(ctx)
+    return _Call(
+        client_name=info.name if info is not None else "",
+        client_version=info.version if info is not None else "",
+        title=(info.title or "")[:FIELD_LIMIT] if info is not None else "",
+        description=(info.description or "")[:FIELD_LIMIT] if info is not None else "",
+        website_url=(info.website_url or "")[:FIELD_LIMIT] if info is not None else "",
+        icon_count=len(info.icons or ()) if info is not None else 0,
+        capabilities=tuple(_capabilities(capabilities).items()),
+        tool=tool,
+        protocol=ctx.protocol_version or "",
+    )
+
+
+@contextmanager
+def scope(ctx: Context, tool: str) -> Iterator[None]:
+    """Bind analytics to the current task for one tool call."""
+    token = _current.set(_snapshot(ctx, tool))
+    try:
+        yield
+    finally:
+        _current.reset(token)
+
+
+def headers() -> dict[str, str]:
+    """Build the analytics headers for the current outbound request."""
+    call = _current.get()
+    result = {f"{PREFIX}Version": PACKAGE_VERSION}
+    if call is None:
+        return result
+
+    discrete = {
+        f"{PREFIX}Client": clean(call.client_name),
+        f"{PREFIX}Client-Version": clean(call.client_version),
+        f"{PREFIX}Tool": clean(call.tool),
+        f"{PREFIX}Protocol": clean(call.protocol),
+    }
+    result.update({name: value for name, value in discrete.items() if value})
+
+    extra: dict[str, object] = {
+        "platform": _PLATFORM,
+        "python": _PYTHON,
+    }
+    for name in ("title", "description", "website_url"):
+        if value := getattr(call, name):
+            extra[name] = value
+    if call.icon_count:
+        extra["icons"] = call.icon_count
+    if call.capabilities:
+        extra["capabilities"] = dict(call.capabilities)
+
+    spent = sum(len(name) + len(value) + 4 for name, value in result.items())
+    droppable = ["description", "title", "website_url", "capabilities", "icons"]
+    while extra:
+        value = as_header(extra)
+        if value and spent + len(CONTEXT_HEADER) + len(value) + 4 <= BUDGET_BYTES:
+            result[CONTEXT_HEADER] = value
+            break
+        if not droppable:
+            break
+        extra.pop(droppable.pop(0), None)
+    return result

--- a/src/delta_exchange_mcp/analytics.py
+++ b/src/delta_exchange_mcp/analytics.py
@@ -1,6 +1,7 @@
 """Bounded analytics headers for outbound Delta API requests."""
 
 import json
+import os
 import platform
 import sys
 from collections.abc import Iterator
@@ -12,9 +13,7 @@ from urllib.parse import quote
 from mcp.server.mcpserver import Context
 from mcp_types import (
     CLIENT_CAPABILITIES_META_KEY,
-    CLIENT_INFO_META_KEY,
     ClientCapabilities,
-    Implementation,
 )
 from mcp_types.version import MODERN_PROTOCOL_VERSIONS
 
@@ -31,18 +30,15 @@ _CLOSED_CAPABILITIES = ("sampling", "elicitation", "roots", "tasks")
 _OPEN_CAPABILITIES = ("experimental", "extensions")
 _PLATFORM = f"{platform.system()} {platform.machine()}"
 _PYTHON = f"{sys.version_info.major}.{sys.version_info.minor}"
+_OFF = frozenset({"off", "false", "0", "no"})
 
 
 @dataclass(frozen=True)
 class _Call:
-    """The non-sensitive analytics fields copied from one MCP tool request."""
+    """The bounded analytics fields copied from one MCP tool request."""
 
     client_name: str = ""
     client_version: str = ""
-    title: str = ""
-    description: str = ""
-    website_url: str = ""
-    icon_count: int = 0
     capabilities: tuple[tuple[str, bool | int], ...] = ()
     tool: str = ""
     protocol: str = ""
@@ -94,54 +90,40 @@ def _capabilities(capabilities: ClientCapabilities | None) -> dict[str, bool | i
     return result
 
 
-def _modern_models(
-    ctx: Context,
-) -> tuple[Implementation | None, ClientCapabilities | None]:
+def _modern_capabilities(ctx: Context) -> ClientCapabilities | None:
     try:
         meta = ctx.request_context.meta
     except ValueError:
-        return None, None
+        return None
     if meta is None:
-        return None, None
+        return None
 
-    raw_info = meta.get(CLIENT_INFO_META_KEY)
     raw_capabilities = meta.get(CLIENT_CAPABILITIES_META_KEY)
     try:
-        info = Implementation.model_validate(raw_info)
+        return ClientCapabilities.model_validate(raw_capabilities)
     except (TypeError, ValueError):
-        info = None
-    try:
-        capabilities = ClientCapabilities.model_validate(raw_capabilities)
-    except (TypeError, ValueError):
-        capabilities = None
-    return info, capabilities
+        return None
 
 
-def _legacy_models(
-    ctx: Context,
-) -> tuple[Implementation | None, ClientCapabilities | None]:
+def _legacy_capabilities(ctx: Context) -> ClientCapabilities | None:
     try:
         params = ctx.session.client_params
     except ValueError:
-        return None, None
+        return None
     if params is None:
-        return None, None
-    return params.client_info, params.capabilities
+        return None
+    return params.capabilities
 
 
 def _snapshot(ctx: Context, tool: str) -> _Call:
     reported = request.context_client(ctx)
     if ctx.protocol_version in MODERN_PROTOCOL_VERSIONS:
-        info, capabilities = _modern_models(ctx)
+        capabilities = _modern_capabilities(ctx)
     else:
-        info, capabilities = _legacy_models(ctx)
+        capabilities = _legacy_capabilities(ctx)
     return _Call(
         client_name=reported.name,
         client_version=reported.version,
-        title=reported.title[:FIELD_LIMIT],
-        description=(info.description or "")[:FIELD_LIMIT] if info is not None else "",
-        website_url=(info.website_url or "")[:FIELD_LIMIT] if info is not None else "",
-        icon_count=len(info.icons or ()) if info is not None else 0,
         capabilities=tuple(_capabilities(capabilities).items()),
         tool=tool,
         protocol=ctx.protocol_version or "",
@@ -160,6 +142,8 @@ def scope(ctx: Context, tool: str) -> Iterator[None]:
 
 def headers() -> dict[str, str]:
     """Build the analytics headers for the current outbound request."""
+    if os.environ.get("DELTA_MCP_ANALYTICS", "on").strip().lower() in _OFF:
+        return {}
     call = _current.get()
     result = {f"{PREFIX}Version": PACKAGE_VERSION}
     if call is None:
@@ -177,16 +161,11 @@ def headers() -> dict[str, str]:
         "platform": _PLATFORM,
         "python": _PYTHON,
     }
-    for name in ("title", "description", "website_url"):
-        if value := getattr(call, name):
-            extra[name] = value
-    if call.icon_count:
-        extra["icons"] = call.icon_count
     if call.capabilities:
         extra["capabilities"] = dict(call.capabilities)
 
     spent = sum(len(name) + len(value) + 4 for name, value in result.items())
-    droppable = ["description", "title", "website_url", "capabilities", "icons"]
+    droppable = ["capabilities"]
     while extra:
         value = as_header(extra)
         if value and spent + len(CONTEXT_HEADER) + len(value) + 4 <= BUDGET_BYTES:

--- a/src/delta_exchange_mcp/client.py
+++ b/src/delta_exchange_mcp/client.py
@@ -15,6 +15,7 @@ from urllib.parse import urlparse
 
 import httpx
 
+from delta_exchange_mcp import analytics
 from delta_exchange_mcp.config import Config
 from delta_exchange_mcp.errors import DeltaApiError
 from delta_exchange_mcp.version import PACKAGE_VERSION
@@ -240,7 +241,7 @@ class DeltaClient:
         # Captured once: a form save may rebind the process while this request is awaiting
         # the network, and its base URL, signing prefix and credential pair must stay one tuple.
         config = state.config
-        headers: dict[str, str] = {}
+        headers = analytics.headers()
         # Delta signs the EXACT request body bytes. Serialize once (compact, no spaces) and
         # feed the same string to both sign() and httpx via content= — using json= would let
         # httpx re-serialize with different spacing and break the signature. Mirrors the

--- a/src/delta_exchange_mcp/request.py
+++ b/src/delta_exchange_mcp/request.py
@@ -25,12 +25,12 @@ session: ContextVar[ServerSession | None] = ContextVar(
 class Client:
     """How the connected host names itself in the handshake.
 
-    Self-reported and unauthenticated: a client may claim any name. It scopes convenience
-    settings and labels analytics. It must never gate anything that carries a safety
-    consequence.
+    Self-reported and unauthenticated: a client may claim any name. Its exact value
+    partitions consent records and labels analytics, but the name does not prove identity
+    or grant consent by itself.
 
     `title` is the host's display name and may be set by the person using it, so it is
-    read for completeness but never sent anywhere or used as a key.
+    included only in bounded analytics and never used as a consent key.
     """
 
     name: str = ""

--- a/src/delta_exchange_mcp/request.py
+++ b/src/delta_exchange_mcp/request.py
@@ -30,7 +30,7 @@ class Client:
     or grant consent by itself.
 
     `title` is the host's display name and may be set by the person using it, so it is
-    included only in bounded analytics and never used as a consent key.
+    used for display only. It is not forwarded in analytics or used as a consent key.
     """
 
     name: str = ""

--- a/src/delta_exchange_mcp/server.py
+++ b/src/delta_exchange_mcp/server.py
@@ -13,7 +13,7 @@ from mcp.server.mcpserver.exceptions import ToolError, UnexpectedToolError
 from mcp.shared.exceptions import MCPError
 from mcp.types import CallToolResult, InputRequiredResult, TextContent
 
-from delta_exchange_mcp import audit_log
+from delta_exchange_mcp import analytics, audit_log
 from delta_exchange_mcp import authorization
 from delta_exchange_mcp import connection_app
 from delta_exchange_mcp import config as config_mod
@@ -126,11 +126,12 @@ class DeltaMCP(MCPServer):
         if context is None:
             context = Context(mcp_server=self, subscriptions=self._subscriptions)
         try:
-            if self._before_tool_call is not None:
-                blocked = await self._before_tool_call(name, arguments, context)
-                if blocked is not None:
-                    return blocked
-            return await super().call_tool(name, arguments, context)
+            with analytics.scope(context, name):
+                if self._before_tool_call is not None:
+                    blocked = await self._before_tool_call(name, arguments, context)
+                    if blocked is not None:
+                        return blocked
+                return await super().call_tool(name, arguments, context)
         except (MCPError, ToolError):
             raise
         except Exception as exc:

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -63,6 +63,7 @@ async def connected(
     mode: str = "auto",
     url_elicitation: bool = False,
     apps: bool = False,
+    client_info: types.Implementation | None = None,
 ) -> AsyncIterator[Client]:
     owned = (
         build_server(
@@ -82,7 +83,8 @@ async def connected(
     client = Client(
         owned,
         mode=mode,
-        client_info=types.Implementation(name=CLIENT_NAME, version="1"),
+        client_info=client_info
+        or types.Implementation(name=CLIENT_NAME, version="1"),
         elicitation_callback=elicit if url_elicitation else None,
         extensions=extensions,
     )

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -58,7 +58,9 @@ async def test_request_identifies_the_exact_client_and_tool() -> None:
         )
     )
 
-    assert sent[f"{analytics.PREFIX}Client"] == "claude-ai (via mcp-remote 0.1.37)"
+    assert sent[f"{analytics.PREFIX}Client"] == (
+        "claude-ai%20(via%20mcp-remote%200.1.37)"
+    )
     assert sent[f"{analytics.PREFIX}Client-Version"] == "1.30096.5"
     assert sent[f"{analytics.PREFIX}Tool"] == "get_ticker"
     assert sent[f"{analytics.PREFIX}Version"] == PACKAGE_VERSION
@@ -121,6 +123,61 @@ async def test_client_name_cannot_inject_an_http_header() -> None:
     assert "\r" not in reported and "\n" not in reported
     assert "%0D%0A" in reported
     assert sent.get("api-key") is None
+
+
+@pytest.mark.parametrize(
+    "client_name",
+    [" leading", "trailing ", f"{'a' * 199} tail"],
+)
+async def test_client_name_spaces_survive_real_http_serialization(
+    client_name: str,
+) -> None:
+    requests: list[bytes] = []
+
+    async def accept(
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        requests.append(await reader.readuntil(b"\r\n\r\n"))
+        body = json.dumps(TICKER).encode()
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+            + f"Content-Length: {len(body)}\r\nConnection: close\r\n\r\n".encode()
+            + body
+        )
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    server = await asyncio.start_server(accept, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    client = DeltaClient(
+        Config(
+            env="india_testnet",
+            base_url=f"http://127.0.0.1:{port}/v2",
+        )
+    )
+    token = analytics._current.set(
+        analytics._Call(client_name=client_name, tool="get_ticker")
+    )
+    try:
+        async with server:
+            await client.get("/tickers/BTCUSD")
+    finally:
+        analytics._current.reset(token)
+        await client.aclose()
+
+    assert len(requests) == 1
+    expected = analytics.clean(client_name)
+    assert expected
+    assert not expected.startswith(" ")
+    assert not expected.endswith(" ")
+    header = next(
+        line
+        for line in requests[0].split(b"\r\n")
+        if line.lower().startswith(b"x-delta-mcp-client:")
+    )
+    assert header.endswith(expected.encode())
 
 
 @respx.mock

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,268 @@
+"""Client and tool analytics on the MCP-to-Delta request path."""
+
+import asyncio
+import json
+import re
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+from mcp import types
+from mcp.server.mcpserver import Context
+
+from delta_exchange_mcp import analytics
+from delta_exchange_mcp.client import DeltaClient
+from delta_exchange_mcp.config import INDIA_TESTNET_REST, Config
+from delta_exchange_mcp.server import build_server
+from delta_exchange_mcp.version import PACKAGE_VERSION
+
+from .test_activation import connected, connection_service
+
+TICKER = {"success": True, "result": {"symbol": "BTCUSD", "mark_price": "1"}}
+
+
+@pytest.fixture(autouse=True)
+def testnet_everywhere(monkeypatch):
+    monkeypatch.setenv("DELTA_MCP_ENV", "india_testnet")
+    monkeypatch.delenv("DELTA_API_KEY", raising=False)
+    monkeypatch.delenv("DELTA_API_SECRET", raising=False)
+    monkeypatch.delenv("DELTA_MCP_MODE", raising=False)
+
+
+async def call_ticker(client_info: types.Implementation) -> httpx.Headers:
+    route = respx.get(f"{INDIA_TESTNET_REST}/tickers/BTCUSD").mock(
+        return_value=httpx.Response(200, json=TICKER)
+    )
+    app = build_server(connection_service=connection_service())
+    try:
+        async with connected(
+            app,
+            mode="2026-07-28",
+            client_info=client_info,
+        ) as client:
+            await client.call_tool("get_ticker", {"symbol": "BTCUSD"})
+    finally:
+        await app.close_live_client()
+    assert route.called
+    return route.calls[-1].request.headers
+
+
+@respx.mock
+async def test_request_identifies_the_exact_client_and_tool() -> None:
+    sent = await call_ticker(
+        types.Implementation(
+            name="claude-ai (via mcp-remote 0.1.37)",
+            version="1.30096.5",
+            title="Claude",
+        )
+    )
+
+    assert sent[f"{analytics.PREFIX}Client"] == "claude-ai (via mcp-remote 0.1.37)"
+    assert sent[f"{analytics.PREFIX}Client-Version"] == "1.30096.5"
+    assert sent[f"{analytics.PREFIX}Tool"] == "get_ticker"
+    assert sent[f"{analytics.PREFIX}Version"] == PACKAGE_VERSION
+    assert sent[f"{analytics.PREFIX}Protocol"] == "2026-07-28"
+    assert json.loads(sent[analytics.CONTEXT_HEADER])["title"] == "Claude"
+    assert f"{analytics.PREFIX}Env" not in sent
+    assert f"{analytics.PREFIX}Mode" not in sent
+    assert f"{analytics.PREFIX}Session" not in sent
+
+
+@respx.mock
+async def test_concurrent_clients_keep_exact_request_identity() -> None:
+    seen: list[tuple[str, str]] = []
+    both_started = asyncio.Event()
+
+    async def respond(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            (
+                request.headers[f"{analytics.PREFIX}Client"],
+                request.headers[f"{analytics.PREFIX}Tool"],
+            )
+        )
+        if len(seen) == 2:
+            both_started.set()
+        await asyncio.wait_for(both_started.wait(), timeout=2)
+        return httpx.Response(200, json=TICKER)
+
+    respx.get(f"{INDIA_TESTNET_REST}/tickers/BTCUSD").mock(side_effect=respond)
+    app = build_server(connection_service=connection_service())
+    try:
+        async with (
+            connected(
+                app,
+                mode="2026-07-28",
+                client_info=types.Implementation(name="client-a", version="1"),
+            ) as first,
+            connected(
+                app,
+                mode="2026-07-28",
+                client_info=types.Implementation(name="client-b", version="2"),
+            ) as second,
+        ):
+            await asyncio.gather(
+                first.call_tool("get_ticker", {"symbol": "BTCUSD"}),
+                second.call_tool("get_ticker", {"symbol": "BTCUSD"}),
+            )
+    finally:
+        await app.close_live_client()
+
+    assert set(seen) == {("client-a", "get_ticker"), ("client-b", "get_ticker")}
+
+
+@respx.mock
+async def test_client_name_cannot_inject_an_http_header() -> None:
+    sent = await call_ticker(
+        types.Implementation(name="evil\r\napi-key: stolen", version="1")
+    )
+
+    reported = sent[f"{analytics.PREFIX}Client"]
+    assert "\r" not in reported and "\n" not in reported
+    assert "%0D%0A" in reported
+    assert sent.get("api-key") is None
+
+
+@respx.mock
+async def test_credentials_never_enter_analytics_headers() -> None:
+    cfg = Config(
+        env="india_testnet",
+        base_url=INDIA_TESTNET_REST,
+        api_key="key-that-must-not-travel",
+        api_secret="secret-that-must-not-travel",
+    )
+    route = respx.get(f"{INDIA_TESTNET_REST}/positions").mock(
+        return_value=httpx.Response(200, json={"success": True, "result": []})
+    )
+    client = DeltaClient(cfg)
+    try:
+        with analytics.scope(Context(), "get_positions"):
+            await client.get("/positions", auth=True)
+    finally:
+        await client.aclose()
+
+    ours = {
+        name: value
+        for name, value in route.calls[-1].request.headers.items()
+        if name.lower().startswith(analytics.PREFIX.lower())
+    }
+    rendered = " ".join(ours.values())
+    assert "key-that-must-not-travel" not in rendered
+    assert "secret-that-must-not-travel" not in rendered
+    assert "signature" not in rendered.lower()
+
+
+@respx.mock
+async def test_long_client_description_cannot_break_the_request() -> None:
+    sent = await call_ticker(
+        types.Implementation(
+            name="verbose",
+            version="1",
+            title="😀" * 5000,
+            description="😀" * 5000,
+            website_url="https://example.test",
+        )
+    )
+
+    total = sum(
+        len(name) + len(value) + 4
+        for name, value in sent.items()
+        if name.lower().startswith(analytics.PREFIX.lower())
+    )
+    assert total <= analytics.BUDGET_BYTES
+    assert sent[f"{analytics.PREFIX}Client"] == "verbose"
+    assert sent[f"{analytics.PREFIX}Tool"] == "get_ticker"
+    assert json.loads(sent[analytics.CONTEXT_HEADER])
+
+
+@respx.mock
+async def test_context_header_is_directly_parseable_json() -> None:
+    sent = await call_ticker(
+        types.Implementation(
+            name="punctuation",
+            version="1",
+            title='he said "hi" \\ and left\nthen returned',
+        )
+    )
+
+    raw = sent[analytics.CONTEXT_HEADER]
+    assert "%5C" not in raw
+    assert raw.isascii() and raw.isprintable()
+    assert json.loads(raw)["title"].startswith('he said "hi"')
+
+
+def test_context_header_rejects_unprintable_output(monkeypatch) -> None:
+    monkeypatch.setattr(analytics.json, "dumps", lambda *args, **kwargs: '{"x":"a\nb"}')
+    assert analytics.as_header({"x": "anything"}) == ""
+
+
+def test_open_capability_settings_are_not_forwarded() -> None:
+    capabilities = types.ClientCapabilities(
+        experimental={"private-extension": {"api_key": "client-secret-value"}},
+        extensions={"another-private-extension": {"token": "private-token"}},
+        roots=types.RootsCapability(listChanged=True),
+    )
+
+    projected = analytics._capabilities(capabilities)
+    rendered = json.dumps(projected)
+    assert projected == {"roots": True, "experimental": 1, "extensions": 1}
+    assert "private-extension" not in rendered
+    assert "client-secret-value" not in rendered
+    assert "private-token" not in rendered
+
+
+@respx.mock
+async def test_encoded_client_fields_stay_bounded() -> None:
+    sent = await call_ticker(types.Implementation(name="😀" * 200, version="😀" * 200))
+
+    for header in (f"{analytics.PREFIX}Client", f"{analytics.PREFIX}Client-Version"):
+        assert len(sent[header]) <= analytics.FIELD_LIMIT
+        assert not re.search(r"%[0-9A-Fa-f]?$", sent[header])
+
+
+@respx.mock
+async def test_unpaired_surrogate_in_client_name_does_not_fail_the_call() -> None:
+    sent = await call_ticker(types.Implementation(name="bad\ud800name", version="1"))
+    assert sent[f"{analytics.PREFIX}Tool"] == "get_ticker"
+    assert "bad" in sent[f"{analytics.PREFIX}Client"]
+
+
+@respx.mock
+async def test_analytics_context_does_not_leak_after_tool_call() -> None:
+    route = respx.get(f"{INDIA_TESTNET_REST}/tickers/BTCUSD").mock(
+        return_value=httpx.Response(200, json=TICKER)
+    )
+    app = build_server(connection_service=connection_service())
+    try:
+        async with connected(
+            app,
+            mode="2026-07-28",
+            client_info=types.Implementation(name="one-call", version="1"),
+        ) as client:
+            await client.call_tool("get_ticker", {"symbol": "BTCUSD"})
+            await app.live_client.get("/tickers/BTCUSD")
+    finally:
+        await app.close_live_client()
+
+    first, second = (call.request.headers for call in route.calls[-2:])
+    assert first[f"{analytics.PREFIX}Client"] == "one-call"
+    assert first[f"{analytics.PREFIX}Tool"] == "get_ticker"
+    assert f"{analytics.PREFIX}Client" not in second
+    assert f"{analytics.PREFIX}Tool" not in second
+    assert second[f"{analytics.PREFIX}Version"] == PACKAGE_VERSION
+
+
+@respx.mock
+async def test_readme_discloses_every_analytics_header() -> None:
+    sent = await call_ticker(
+        types.Implementation(name="documented-client", version="1", title="Client")
+    )
+    forwarded = {
+        name for name in sent if name.lower().startswith(analytics.PREFIX.lower())
+    }
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    documented = set(re.findall(r"`(X-Delta-MCP-[A-Za-z-]+)`", readme.read_text()))
+    documented_lower = {item.lower() for item in documented}
+
+    missing = sorted(name for name in forwarded if name.lower() not in documented_lower)
+    assert not missing, f"forwarded but undocumented: {missing}"

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -28,6 +28,7 @@ def testnet_everywhere(monkeypatch):
     monkeypatch.delenv("DELTA_API_KEY", raising=False)
     monkeypatch.delenv("DELTA_API_SECRET", raising=False)
     monkeypatch.delenv("DELTA_MCP_MODE", raising=False)
+    monkeypatch.delenv("DELTA_MCP_ANALYTICS", raising=False)
 
 
 async def call_ticker(client_info: types.Implementation) -> httpx.Headers:
@@ -65,7 +66,7 @@ async def test_request_identifies_the_exact_client_and_tool() -> None:
     assert sent[f"{analytics.PREFIX}Tool"] == "get_ticker"
     assert sent[f"{analytics.PREFIX}Version"] == PACKAGE_VERSION
     assert sent[f"{analytics.PREFIX}Protocol"] == "2026-07-28"
-    assert json.loads(sent[analytics.CONTEXT_HEADER])["title"] == "Claude"
+    assert "title" not in json.loads(sent[analytics.CONTEXT_HEADER])
     assert f"{analytics.PREFIX}Env" not in sent
     assert f"{analytics.PREFIX}Mode" not in sent
     assert f"{analytics.PREFIX}Session" not in sent
@@ -245,7 +246,8 @@ async def test_context_header_is_directly_parseable_json() -> None:
     raw = sent[analytics.CONTEXT_HEADER]
     assert "%5C" not in raw
     assert raw.isascii() and raw.isprintable()
-    assert json.loads(raw)["title"].startswith('he said "hi"')
+    assert set(json.loads(raw)) <= {"platform", "python", "capabilities"}
+    assert "he said" not in raw
 
 
 def test_context_header_rejects_unprintable_output(monkeypatch) -> None:
@@ -323,3 +325,34 @@ async def test_readme_discloses_every_analytics_header() -> None:
 
     missing = sorted(name for name in forwarded if name.lower() not in documented_lower)
     assert not missing, f"forwarded but undocumented: {missing}"
+
+
+@respx.mock
+async def test_client_free_text_is_not_forwarded() -> None:
+    marker = "private-client-metadata"
+    sent = await call_ticker(
+        types.Implementation(
+            name="client",
+            version="1",
+            title=marker,
+            description=marker,
+            website_url=f"https://example.test/{marker}",
+            icons=[types.Icon(src=f"https://example.test/{marker}.png")],
+        )
+    )
+    assert marker not in " ".join(sent.values())
+    assert set(json.loads(sent[analytics.CONTEXT_HEADER])) <= {
+        "platform",
+        "python",
+        "capabilities",
+    }
+
+
+@pytest.mark.parametrize("value", ["off", "false", "0", "no", " OFF "])
+@respx.mock
+async def test_opt_out_removes_analytics_without_blocking_requests(monkeypatch, value):
+    monkeypatch.setenv("DELTA_MCP_ANALYTICS", value)
+    sent = await call_ticker(types.Implementation(name="client", version="1"))
+    assert not any(name.lower().startswith(analytics.PREFIX.lower()) for name in sent)
+    assert analytics.headers() == {}
+    assert "user-agent" in sent


### PR DESCRIPTION
Outbound Delta API requests include bounded client and tool analytics. The process can disable the complete analytics header set with `DELTA_MCP_ANALYTICS=off`. This includes the package-version header.

The [analytics code](https://github.com/delta-exchange/delta-exchange-mcp/blob/19b847efdc9d8dbffe6112703e949650c304b978/src/delta_exchange_mcp/analytics.py) sends the package version, client-reported name and version, tool name, MCP protocol, operating system and architecture, Python version, and capability presence or counts. It omits client title, description, website, icons, and extension names and values. Each discrete field is bounded to 200 encoded characters. The complete header set is bounded to 4,096 bytes.

Analytics uses context local to one tool call. It does not make an authorization decision. [Tests](https://github.com/delta-exchange/delta-exchange-mcp/blob/19b847efdc9d8dbffe6112703e949650c304b978/tests/test_analytics.py) cover concurrent calls, encoded input, bounds, modern and legacy metadata, excluded fields, and all accepted opt-out values. The README names the transmitted fields, explains the opt-out, and distinguishes package behavior from retention in Delta's receiving systems. The package does not establish that external retention period.

This PR targets #75. PR #29 follows it.

Reviewed head: `19b847efdc9d8dbffe6112703e949650c304b978`.

Local Python 3.13 verification on the committed tree reports **534 passed, 2 skipped** with `uv run --no-sync --python 3.13 pytest -q`. `uv run --no-sync --python 3.13 ruff check src tests scripts packaging` and `git diff --check` pass.

These are local source checks. Hosted CI, required review, merge, and release are separate states. No real Delta credential, authenticated testnet request, or trade is used in this repair.
